### PR TITLE
Adding charge to charge intent and subscription to match API payload

### DIFF
--- a/src/types/charge_intents.ts
+++ b/src/types/charge_intents.ts
@@ -1,4 +1,5 @@
-import type { Address } from "./customers";
+import type { Address } from './customers';
+import type { PaymentMethod } from './payment_methods';
 
 export enum ChargeIntentStatus {
   INCOMPLETE = 'incomplete',
@@ -6,14 +7,41 @@ export enum ChargeIntentStatus {
   CANCELED = 'canceled',
   REFUNDED = 'refunded',
   REVERSED = 'reversed',
-  FAILED = 'failed', 
+  FAILED = 'failed',
   DISPUTED = 'disputed',
-  SUCCEEDED = 'succeeded'
+  SUCCEEDED = 'succeeded',
 }
 
 export enum AuthorizationMode {
   AUTOMATIC = 'automatic',
-  MANUAL = 'manual'
+  MANUAL = 'manual',
+}
+
+export enum ChargeStatus {
+  SUCCEEDED = 'succeeded',
+  FAILED = 'failed',
+}
+
+export interface Charge {
+  id: string;
+  currency: string;
+  amount_captured: number;
+  amount_refunded: number;
+  captured: boolean;
+  disputed: boolean;
+  charge_intent: string;
+  refunded: boolean;
+  failure_code: string | null;
+  failure_message: string | null;
+  description: string | null;
+  status: ChargeStatus;
+  payment_method_details: PaymentMethod;
+  customer: string;
+  payment_method: string;
+  amount: number;
+  created: number;
+  updated: number;
+  livemode: boolean;
 }
 
 export interface ChargeIntent {
@@ -23,7 +51,7 @@ export interface ChargeIntent {
   status: ChargeIntentStatus;
   description?: string | null;
   metadata?: Record<string, any>;
-  latest_charge?: Record<string, any>;
+  latest_charge?: Charge;
   customer?: string;
   payment_method?: string;
   client_secret?: string;

--- a/src/types/charge_intents.ts
+++ b/src/types/charge_intents.ts
@@ -31,9 +31,9 @@ export interface Charge {
   disputed: boolean;
   charge_intent: string;
   refunded: boolean;
-  failure_code: string | null;
-  failure_message: string | null;
-  description: string | null;
+  failure_code?: string | null;
+  failure_message?: string | null;
+  description?: string | null;
   status: ChargeStatus;
   payment_method_details: PaymentMethod;
   customer: string;

--- a/src/types/subscriptions.ts
+++ b/src/types/subscriptions.ts
@@ -1,8 +1,10 @@
+import type { Charge } from './charge_intents';
+
 export enum SubscriptionStatus {
   PENDING = 'pending',
   ACTIVE = 'active',
   TERMINATED = 'terminated',
-  CANCELED = 'canceled'
+  CANCELED = 'canceled',
 }
 
 export interface PlanDetails {
@@ -28,6 +30,7 @@ export interface Subscription {
   status?: SubscriptionStatus;
   customer?: string;
   default_payment_method?: string;
+  latest_charge?: Charge;
   plan?: PlanDetails;
   metadata?: Record<string, any>;
   object?: string;


### PR DESCRIPTION
Adding a `Charge` interface to be exported from the library, also attaching this to the `ChargeIntent` and `Subscription` payloads to match the actual output of the Frame API. Closes https://github.com/Frame-Payments/frame-node/issues/6