### PR TITLE
Exporting `EventPayload` and correcting `ChargeIntent`

### DIFF
--- a/src/types/charge_intents.ts
+++ b/src/types/charge_intents.ts
@@ -1,4 +1,4 @@
-import type { Address } from './customers';
+import type { Address, Customer } from './customers';
 import type { PaymentMethod } from './payment_methods';
 
 export enum ChargeIntentStatus {
@@ -52,8 +52,10 @@ export interface ChargeIntent {
   description?: string | null;
   metadata?: Record<string, any>;
   latest_charge?: Charge;
-  customer?: string;
-  payment_method?: string;
+  customer?: Customer;
+  payment_method?: PaymentMethod;
+  subscription?: string;
+  invoice?: string;
   client_secret?: string;
   authorization_mode?: string;
   failure_description?: string | null;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -68,7 +68,7 @@ export enum EventType {
 }
 
 // The general payload for all events
-interface EventPayload<T extends EventType, D extends unknown> {
+export interface EventPayload<T extends EventType, D extends unknown> {
   id: string;
   type: T;
   object: string;

--- a/src/types/payment_methods.ts
+++ b/src/types/payment_methods.ts
@@ -2,7 +2,8 @@ import type { Address } from "./customers";
 
 export enum PaymentMethodStatus {
   ACTIVE = 'active',
-  BLOCKED = 'blocked'
+  BLOCKED = 'blocked',
+  DETACHED = 'detached'
 }
 
 export enum PaymentAccountType {


### PR DESCRIPTION
I've corrected the types for `ChargeIntent` which actually unwrap some of the objects included in the response. Likewise, I've exported `EventPayload` so that you can do the following `const body = JSON.parse(rawBody) as EventPayload<EventType, unknown>;` when receiving a webhook.