### PR TITLE
[FRA 4117] frame-node SDK: support configurable baseURL for local API testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@ const subscription = await frame.subscriptions.create({
 console.log(subscription.status); // e.g. active
 ```
 
+### Local development against a self-hosted Frame OS
+
+Frame engineers can point the SDK at a local Frame OS instance (e.g. served by puma-dev as `http://api.framepayments.test`) by passing `baseURL`:
+
+```ts
+const frame = new FrameSDK({
+  apiKey: 'sk_...',
+  baseURL: 'http://api.framepayments.test',
+});
+```
+
+`baseURL` is optional. When omitted, the SDK defaults to `https://api.framepayments.com`, so existing integrations are unaffected.
+
 ## 📱 Client-side (mobile) usage
 
 For mobile clients running on Frame's React Native SDK (`framepayments-react-native@4+`), initialize with the **publishable** key only and call publishable-keyed endpoints:

--- a/src/client.ts
+++ b/src/client.ts
@@ -5,6 +5,10 @@ import { FrameAPIError } from './errors/frame_api_error';
 export interface ClientConfig {
   apiKey?: string;
   publishableKey?: string;
+  // Override the API base URL. Defaults to https://api.framepayments.com.
+  // Useful for pointing local development at a self-hosted Frame OS instance
+  // (e.g. http://api.framepayments.test via puma-dev).
+  baseURL?: string;
   // Headers to attach to every request from this client. Used by the React
   // Native SDK to forward the device IP via `ip_address` on each call (matches
   // the native Frame iOS / Frame Android behavior). The request interceptor
@@ -56,7 +60,7 @@ export const createApiClient = (config: ClientConfig): AxiosInstance => {
     );
   }
 
-  const baseURL = 'https://api.framepayments.com';
+  const baseURL = config.baseURL ?? 'https://api.framepayments.com';
 
   const client = axios.create({
     baseURL,

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -3,6 +3,7 @@
 import nock from 'nock';
 import { createApiClient, withPublishableKey, maybePublishableKey } from '../src/client';
 import { FrameAPIError } from '../src/errors/frame_api_error';
+import { FrameSDK } from '../src';
 
 const baseUrl = 'https://api.framepayments.com';
 
@@ -225,6 +226,41 @@ describe('defaultHeaders — per-request attachment', () => {
       .reply(200, { data: [] });
 
     await client.get('/v1/customers');
+  });
+});
+
+describe('baseURL override', () => {
+  test('defaults to the production base URL when none is supplied', async () => {
+    const client = createApiClient({ apiKey: 'sk_test' });
+
+    nock('https://api.framepayments.com').get('/v1/customers').reply(200, { data: [] });
+
+    const resp = await client.get('/v1/customers');
+    expect(resp.status).toBe(200);
+  });
+
+  test('routes requests to a custom baseURL when supplied', async () => {
+    const customBase = 'http://api.framepayments.test';
+    const client = createApiClient({ apiKey: 'sk_test', baseURL: customBase });
+
+    nock(customBase, {
+      reqheaders: { authorization: 'Bearer sk_test' },
+    })
+      .get('/v1/customers')
+      .reply(200, { data: [] });
+
+    const resp = await client.get('/v1/customers');
+    expect(resp.status).toBe(200);
+  });
+
+  test('FrameSDK forwards baseURL to the underlying client', async () => {
+    const customBase = 'http://api.framepayments.test';
+    const frame = new FrameSDK({ apiKey: 'sk_test', baseURL: customBase });
+
+    nock(customBase).get('/v1/customers/cust_123').reply(200, { id: 'cust_123' });
+
+    const customer = await frame.customers.get('cust_123');
+    expect(customer.id).toBe('cust_123');
   });
 });
 


### PR DESCRIPTION
https://linear.app/framepayments/issue/FRA-4117/frame-node-sdk-support-configurable-baseurl-for-local-api-testing