### PR TITLE
fix(subscriptions): make customer optional to allow account-based subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.1
+
+- `CreateSubscriptionParams.customer` is now optional, with `account` already optional, so subscriptions can be created against an account instead of a customer. The `/v1/subscriptions` API has accepted `account` for a while and enforces exactly-one-of (customer or account); the SDK type previously marked `customer` as required, blocking account-based subscriptions at compile time. Mirrors `CreateChargeIntentParams`.
+
 ## 2.1.5
 
 Parity pass against Frame iOS 3.0.0 as the source-of-truth schema:

--- a/src/types/subscriptions.ts
+++ b/src/types/subscriptions.ts
@@ -62,11 +62,14 @@ export interface SubscriptionListResponse {
 }
 
 export interface CreateSubscriptionParams {
-  customer: string;
+  // Provide exactly one owner: either `customer` or `account` (not both).
+  // The API enforces this; both are optional here to support account-based
+  // subscriptions, mirroring CreateChargeIntentParams.
+  customer?: string;
+  account?: string;
   product: string;
   currency: string;
   default_payment_method?: string;
-  account?: string;
   description?: string;
   proration_behavior?: string;
   metadata?: Record<string, any>;

--- a/tests/subscriptions.test.ts
+++ b/tests/subscriptions.test.ts
@@ -36,6 +36,25 @@ test('create subscription', async () => {
   expect(result).toEqual(mockSubscription);
 });
 
+test('create account-based subscription', async () => {
+  const input = {
+    account: 'acct_abc',
+    product: 'prod_123',
+    currency: 'usd',
+    default_payment_method: 'pm_123',
+  };
+  const accountSubscription = {
+    ...mockSubscription,
+    customer: undefined,
+    account: 'acct_abc',
+  };
+
+  nock(baseUrl).post('/v1/subscriptions', input).reply(200, accountSubscription);
+
+  const result = await subscriptions.create(input);
+  expect(result).toEqual(accountSubscription);
+});
+
 test('get subscription', async () => {
   nock(baseUrl).get('/v1/subscriptions/sub_123').reply(200, mockSubscription);
 


### PR DESCRIPTION
## What changed

`CreateSubscriptionParams.customer` is now **optional** (it was required); `account` was already optional. Both are now optional, matching `CreateChargeIntentParams`.

```ts
export interface CreateSubscriptionParams {
  // Provide exactly one owner: either `customer` or `account` (not both).
  customer?: string;   // was: customer: string
  account?: string;
  product: string;
  currency: string;
  ...
}
```

## Why

A merchant moving from customers to accounts hit this: `subscriptions.create({ account, product, currency, default_payment_method })` failed TypeScript compilation because `customer` was marked required, forcing an `as any` cast or a dummy `customer`.

It's purely a typing lag. `SubscriptionsAPI.create()` is a straight passthrough to `POST /v1/subscriptions`, and that endpoint has accepted `account` for a while — it enforces exactly-one-of (customer **or** account, not both) server-side. The `Subscription` response type already models both (`customer?`, `account?`); only the create-params type was stale.

## Why this shape (both optional) over a strict one-of union

The API's exactly-one-of rule could be encoded as a discriminated union (`{ customer } | { account }`). I matched the existing SDK convention instead — `CreateChargeIntentParams` already models the same customer/account choice as two optional fields and lets the API enforce the rule. Keeping subscriptions consistent with charge intents avoids a one-off pattern; the server is the source of truth for the validation either way.

## What's NOT in this PR

- No version bump in `package.json` (left to the usual `version bump` release commit). CHANGELOG entry added under `2.3.1`.
- No runtime validation added to the SDK — the API remains the enforcement point, consistent with the rest of the client.

## Test coverage

- Added `create account-based subscription` to `tests/subscriptions.test.ts`, calling `subscriptions.create({ account, ... })` **without** an `as any` cast — so it doubles as a compile-time guard that the account-only path type-checks.
- `npx tsc --noEmit` clean; full suite green (147 tests, 23 suites).

## How to Test

```sh
npm install
npx tsc --noEmit
npx jest tests/subscriptions.test.ts
```

The new test should pass and the suite should type-check with no cast on the account-only `create` call.

## Checklist

- [x] Types updated (`customer` optional, mirrors charge intents)
- [x] Test added for account-only create (no cast)
- [x] Typecheck + full test suite pass
- [x] CHANGELOG updated
- [ ] Version bump (release flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)