### PR TITLE
Added new support for Publishable Key, Client secret and Onboarding Sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Publishable-key-only mobile clients (starting with `framepayments-react-native`,
 - **Per-object client secrets.** `RequestOptions` gains `authToken?: string`, a per-request bearer override for sending an object `client_secret` (e.g. `ci_..._secret_...`) on charge-intent confirm/show and 3-D Secure. `chargeIntents.get` now accepts options; `threeDS.create/get/resend` now accept options.
 - **Auth precedence** in the request interceptor is now exactly: per-request `authToken` > active onboarding-session token > publishable/secret key. The interceptor no longer unconditionally overwrites `Authorization` with the key-derived bearer — higher-precedence overrides win.
 - **`usePublishableKey` coverage** added to the onboarding-flow methods: `threeDS.create/get/resend`, `termsOfService.createToken`, `capabilities.list/request`, and `onboardingSessions.create/getByAccount`.
+- **Auth routing is carried on the axios request config, not on HTTP headers.** The per-request `authToken` (client_secret) and publishable-key flag travel as internal config fields that never serialize onto the wire, so the secret cannot leak as a header and a caller-supplied header cannot spoof key routing.
+- **An explicitly empty `authToken` is rejected** with `code: 'invalid_auth_token'` instead of silently falling through to the session/publishable/secret key.
 
 No breaking changes — all new parameters are optional and default to the prior behavior.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.4.0
+
+Publishable-key-only mobile clients (starting with `framepayments-react-native`, FRA-4315) can now authenticate **onboarding sessions** and **per-object client secrets**, matching the three-tier auth resolver of the native Frame iOS / Android SDKs (FRA-4712).
+
+- **Onboarding sessions.** `FrameSDK` gains `setOnboardingSession(token)` and `clearOnboardingSession(token?)`. While a session is active, every request sends `Authorization: Bearer <token>` (e.g. `onb_sess_...`), overriding the configured publishable/secret keys regardless of `usePublishableKey`. Mirrors iOS `beginOnboardingSession` / `endOnboardingSession`. `clearOnboardingSession(token?)` is **safe-clear**: it only clears when `token` is omitted or matches the active token (so a stale unmount cannot wipe a newer session), returning `true`/`false` accordingly. Mirrors Android's guarded teardown.
+- **Per-object client secrets.** `RequestOptions` gains `authToken?: string`, a per-request bearer override for sending an object `client_secret` (e.g. `ci_..._secret_...`) on charge-intent confirm/show and 3-D Secure. `chargeIntents.get` now accepts options; `threeDS.create/get/resend` now accept options.
+- **Auth precedence** in the request interceptor is now exactly: per-request `authToken` > active onboarding-session token > publishable/secret key. The interceptor no longer unconditionally overwrites `Authorization` with the key-derived bearer — higher-precedence overrides win.
+- **`usePublishableKey` coverage** added to the onboarding-flow methods: `threeDS.create/get/resend`, `termsOfService.createToken`, `capabilities.list/request`, and `onboardingSessions.create/getByAccount`.
+
+No breaking changes — all new parameters are optional and default to the prior behavior.
+
 ## 2.3.1
 
 - `CreateSubscriptionParams.customer` is now optional, with `account` already optional, so subscriptions can be created against an account instead of a customer. The `/v1/subscriptions` API has accepted `account` for a while and enforces exactly-one-of (customer or account); the SDK type previously marked `customer` as required, blocking account-based subscriptions at compile time. Mirrors `CreateChargeIntentParams`.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,42 @@ await frame.configuration.getEvervaultConfiguration({ usePublishableKey: true })
 
 The SDK defaults match the native Frame iOS / Android SDKs exactly — endpoints that those SDKs invoke with `usePublishableKey: true` are publishable-by-default here as well (`paymentMethods.createApplePayPaymentMethod`, `paymentMethods.createGooglePayPaymentMethod`, `deviceAttestation.*`, `wallet.getGooglePayConfiguration`). Everything else defaults to secret.
 
+## 🪪 Onboarding sessions & per-object client secrets
+
+Publishable-key-only mobile clients can authenticate **onboarding sessions** and **per-object client secrets**, matching the three-tier auth model of the native Frame iOS / Android SDKs. The bearer for any request is resolved in this precedence order:
+
+1. a per-request `authToken` (an object `client_secret`, e.g. `ci_..._secret_...`), else
+2. the active onboarding-session token (e.g. `onb_sess_...`), else
+3. the publishable key (when `usePublishableKey: true`) or the secret key.
+
+### Onboarding sessions
+
+Begin a session to route **every** request through the session token, overriding the configured keys (and ignoring `usePublishableKey`) while it is active. Mirrors iOS `beginOnboardingSession` / `endOnboardingSession`.
+
+```ts
+const frame = new FrameSDK({ publishableKey: 'pk_...' });
+
+frame.setOnboardingSession('onb_sess_...');
+// Every call now sends `Authorization: Bearer onb_sess_...`.
+await frame.onboardingSessions.create({ /* ... */ });
+await frame.termsOfService.createToken();
+
+// End the session, reverting to the publishable key.
+frame.clearOnboardingSession();
+```
+
+`clearOnboardingSession(token?)` is **safe-clear**: passing a `token` only clears the session when it matches the active one (so a stale unmount can't wipe a newer session), and returns `true` if it cleared / `false` if the guard prevented it. Omit the argument to force-clear.
+
+### Per-object client secrets
+
+For charge-intent confirm/show and 3-D Secure, pass the object's `client_secret` as a per-request `authToken`. It wins over both an active session and the configured keys:
+
+```ts
+await frame.chargeIntents.confirm('ci_123', { authToken: 'ci_123_secret_...' });
+await frame.chargeIntents.get('ci_123', { authToken: 'ci_123_secret_...' });
+await frame.threeDS.get('tds_123', { authToken: 'tds_123_secret_...' });
+```
+
 ## 📚 Available APIs
 
 | Namespace | Purpose |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "framepayments",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "The Frame Node.js Library simplifies the process of creating a seamless payment experience within your web app. it provides access to the underlying APIs that drive these components, allowing you to design fully customized payment workflows tailored to your app's needs.",
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.cts",

--- a/src/api/capabilities-api.ts
+++ b/src/api/capabilities-api.ts
@@ -1,16 +1,17 @@
 import type { AxiosInstance } from 'axios';
 import type { Capability, RequestCapabilitiesParams } from '../types/capabilities';
+import { maybePublishableKey, type RequestOptions } from '../client';
 
 export class CapabilitiesAPI {
   constructor(private client: AxiosInstance) {}
 
-  async list(accountId: string): Promise<Capability[]> {
-    const resp = await this.client.get(`/v1/accounts/${accountId}/capabilities`);
+  async list(accountId: string, opts?: RequestOptions): Promise<Capability[]> {
+    const resp = await this.client.get(`/v1/accounts/${accountId}/capabilities`, maybePublishableKey(opts));
     return resp.data;
   }
 
-  async request(accountId: string, params: RequestCapabilitiesParams): Promise<Capability[]> {
-    const resp = await this.client.post(`/v1/accounts/${accountId}/capabilities`, params);
+  async request(accountId: string, params: RequestCapabilitiesParams, opts?: RequestOptions): Promise<Capability[]> {
+    const resp = await this.client.post(`/v1/accounts/${accountId}/capabilities`, params, maybePublishableKey(opts));
     return resp.data;
   }
 

--- a/src/api/charge_intents-api.ts
+++ b/src/api/charge_intents-api.ts
@@ -22,8 +22,8 @@ export class ChargeIntentsAPI {
     return resp.data;
   }
 
-  async get(id: string): Promise<ChargeIntent> {
-    const resp = await this.client.get(`/v1/charge_intents/${id}`);
+  async get(id: string, opts?: RequestOptions): Promise<ChargeIntent> {
+    const resp = await this.client.get(`/v1/charge_intents/${id}`, maybePublishableKey(opts));
     return resp.data;
   }
 

--- a/src/api/onboarding_sessions-api.ts
+++ b/src/api/onboarding_sessions-api.ts
@@ -1,17 +1,19 @@
 import type { AxiosInstance } from 'axios';
 import type { OnboardingSession, CreateOnboardingSessionParams } from '../types/onboarding_sessions';
+import { maybePublishableKey, type RequestOptions } from '../client';
 
 export class OnboardingSessionsAPI {
   constructor(private client: AxiosInstance) {}
 
-  async create(params: CreateOnboardingSessionParams): Promise<OnboardingSession> {
-    const resp = await this.client.post('/v1/onboarding_sessions', params);
+  async create(params: CreateOnboardingSessionParams, opts?: RequestOptions): Promise<OnboardingSession> {
+    const resp = await this.client.post('/v1/onboarding_sessions', params, maybePublishableKey(opts));
     return resp.data;
   }
 
-  async getByAccount(accountId: string): Promise<OnboardingSession> {
+  async getByAccount(accountId: string, opts?: RequestOptions): Promise<OnboardingSession> {
     const resp = await this.client.get('/v1/onboarding_sessions', {
-      params: { account_id: accountId }
+      ...maybePublishableKey(opts),
+      params: { account_id: accountId },
     });
     return resp.data;
   }

--- a/src/api/terms_of_service-api.ts
+++ b/src/api/terms_of_service-api.ts
@@ -1,11 +1,12 @@
 import type { AxiosInstance } from 'axios';
 import type { TermsOfServiceTokenResponse, UpdateTermsOfServiceParams } from '../types/terms_of_service';
+import { maybePublishableKey, type RequestOptions } from '../client';
 
 export class TermsOfServiceAPI {
   constructor(private client: AxiosInstance) {}
 
-  async createToken(): Promise<TermsOfServiceTokenResponse> {
-    const resp = await this.client.post('/v1/terms_of_service', {});
+  async createToken(opts?: RequestOptions): Promise<TermsOfServiceTokenResponse> {
+    const resp = await this.client.post('/v1/terms_of_service', {}, maybePublishableKey(opts));
     return resp.data;
   }
 

--- a/src/api/three_ds-api.ts
+++ b/src/api/three_ds-api.ts
@@ -1,21 +1,22 @@
 import type { AxiosInstance } from 'axios';
 import type { ThreeDSIntent, CreateThreeDSIntentParams } from '../types/three_ds';
+import { maybePublishableKey, type RequestOptions } from '../client';
 
 export class ThreeDSAPI {
   constructor(private client: AxiosInstance) {}
 
-  async create(params: CreateThreeDSIntentParams): Promise<ThreeDSIntent> {
-    const resp = await this.client.post('/v1/3ds/intents', params);
+  async create(params: CreateThreeDSIntentParams, opts?: RequestOptions): Promise<ThreeDSIntent> {
+    const resp = await this.client.post('/v1/3ds/intents', params, maybePublishableKey(opts));
     return resp.data;
   }
 
-  async get(id: string): Promise<ThreeDSIntent> {
-    const resp = await this.client.get(`/v1/3ds/intents/${id}`);
+  async get(id: string, opts?: RequestOptions): Promise<ThreeDSIntent> {
+    const resp = await this.client.get(`/v1/3ds/intents/${id}`, maybePublishableKey(opts));
     return resp.data;
   }
 
-  async resend(id: string): Promise<ThreeDSIntent> {
-    const resp = await this.client.post(`/v1/3ds/intents/${id}/resend`);
+  async resend(id: string, opts?: RequestOptions): Promise<ThreeDSIntent> {
+    const resp = await this.client.post(`/v1/3ds/intents/${id}/resend`, undefined, maybePublishableKey(opts));
     return resp.data;
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -26,6 +26,20 @@ export interface RequestOptions {
   authToken?: string;
 }
 
+// Internal auth routing is carried on the axios request *config* (not on
+// headers). Axios passes unknown config fields straight through to the request
+// interceptor untouched and never serializes them onto the wire, so a secret
+// `frameAuthToken` can never leak as an HTTP header and there is nothing to
+// strip before the request leaves the process. Callers cannot reach these
+// fields through the public helpers' header path, so a raw header named like
+// the old smuggle keys can no longer override key routing.
+interface FrameRequestConfig extends AxiosRequestConfig {
+  frameUsePublishableKey?: boolean;
+  frameAuthToken?: string;
+}
+const FRAME_USE_PUBLISHABLE_KEY = 'frameUsePublishableKey';
+const FRAME_AUTH_TOKEN = 'frameAuthToken';
+
 // Holds the active onboarding-session bearer token (e.g. `onb_sess_...`). The
 // request interceptor closes over a single instance of this so the token can be
 // set/cleared on the live client after construction, mirroring the native iOS
@@ -38,28 +52,24 @@ export interface OnboardingSessionStore {
 
 export const createOnboardingSessionStore = (): OnboardingSessionStore => ({ token: null });
 
-const PUBLISHABLE_FLAG_KEY = 'X-Frame-Use-Publishable-Key';
-// Per-request bearer override, smuggled through the request config headers so it
-// rides the normal axios call path, then stripped by the interceptor before the
-// request leaves the process (just like the publishable-key flag).
-const AUTH_TOKEN_KEY = 'X-Frame-Auth-Token';
-
-// Strips the Authorization header before stashing axios's error config on
-// FrameAPIError.raw — without this, every network-layer failure would leak
-// the live Bearer token to anyone logging the error.
+// Strips the Authorization header and the per-request `frameAuthToken` (an
+// object client_secret) before stashing axios's error config on
+// FrameAPIError.raw — without this, every network-layer failure would leak the
+// live Bearer token / client_secret to anyone logging the error.
 function safeRawFromAxiosError(err: any): unknown {
   if (!err || typeof err !== 'object') return err;
   const cleanedConfig = err.config
     ? (() => {
-        const { headers, ...restConfig } = err.config as { headers?: unknown } & Record<string, unknown>;
+        const {
+          headers,
+          [FRAME_AUTH_TOKEN]: _authToken,
+          ...restConfig
+        } = err.config as { headers?: unknown } & Record<string, unknown>;
         const cleanedHeaders =
           headers && typeof headers === 'object'
             ? Object.fromEntries(
                 Object.entries(headers as Record<string, unknown>).filter(
-                  ([k]) =>
-                    k.toLowerCase() !== 'authorization' &&
-                    k !== PUBLISHABLE_FLAG_KEY &&
-                    k !== AUTH_TOKEN_KEY,
+                  ([k]) => k.toLowerCase() !== 'authorization',
                 ),
               )
             : headers;
@@ -96,25 +106,23 @@ export const createApiClient = (
 
   client.interceptors.request.use((requestConfig: InternalAxiosRequestConfig) => {
     const headers = requestConfig.headers;
-    const wantsPublishable = headers instanceof AxiosHeaders
-      ? headers.has(PUBLISHABLE_FLAG_KEY)
-      : Boolean((headers as Record<string, unknown> | undefined)?.[PUBLISHABLE_FLAG_KEY]);
-
-    const perRequestAuthToken = headers instanceof AxiosHeaders
-      ? (headers.get(AUTH_TOKEN_KEY) as string | undefined)
-      : ((headers as Record<string, unknown> | undefined)?.[AUTH_TOKEN_KEY] as string | undefined);
-
-    if (headers instanceof AxiosHeaders) {
-      headers.delete(PUBLISHABLE_FLAG_KEY);
-      headers.delete(AUTH_TOKEN_KEY);
-    } else if (headers) {
-      if (PUBLISHABLE_FLAG_KEY in (headers as Record<string, unknown>)) {
-        delete (headers as Record<string, unknown>)[PUBLISHABLE_FLAG_KEY];
-      }
-      if (AUTH_TOKEN_KEY in (headers as Record<string, unknown>)) {
-        delete (headers as Record<string, unknown>)[AUTH_TOKEN_KEY];
-      }
+    const cfg = requestConfig as FrameRequestConfig;
+    const wantsPublishable = cfg.frameUsePublishableKey === true;
+    // An explicitly-provided but empty authToken is a caller bug (e.g. an
+    // unpopulated client_secret). Fail loudly rather than silently fall through
+    // to the session/pk/sk bearer, which would send the request under a
+    // broader-privilege credential than intended.
+    const rawAuthToken = cfg.frameAuthToken;
+    if (rawAuthToken === '') {
+      throw new FrameAPIError(
+        'Frame authToken was provided but empty. Pass a non-empty client_secret (e.g. ci_..._secret_...), or omit authToken to use the configured key.',
+        'invalid_auth_token',
+        0,
+        null,
+      );
     }
+    const perRequestAuthToken =
+      typeof rawAuthToken === 'string' && rawAuthToken.length > 0 ? rawAuthToken : undefined;
 
     if (defaultHeaders) {
       for (const [name, value] of Object.entries(defaultHeaders)) {
@@ -180,26 +188,23 @@ export const createApiClient = (
   return client;
 };
 
-// Translates RequestOptions into the internal smuggle-headers that the request
-// interceptor understands: the publishable-key routing flag and the per-request
-// authToken override. `publishableDefault` differs between the two public
-// helpers (withPublishableKey opts in by default, maybePublishableKey opts out).
+// Translates RequestOptions into the internal axios *config* fields the request
+// interceptor reads (frameUsePublishableKey / frameAuthToken). These never
+// become wire headers, so the per-request client_secret can't leak and a raw
+// caller-supplied header can't spoof key routing. `publishableDefault` differs
+// between the two public helpers (withPublishableKey opts in by default,
+// maybePublishableKey opts out).
 function buildRequestConfig(
   publishableDefault: boolean,
   opts?: RequestOptions & AxiosRequestConfig,
 ): AxiosRequestConfig {
-  const { usePublishableKey = publishableDefault, authToken, headers, ...rest } = opts ?? {};
-  const extraHeaders: Record<string, string> = {};
-  if (usePublishableKey) extraHeaders[PUBLISHABLE_FLAG_KEY] = '1';
-  if (authToken) extraHeaders[AUTH_TOKEN_KEY] = authToken;
-
-  if (Object.keys(extraHeaders).length === 0) {
-    return headers ? { ...rest, headers } : { ...rest };
-  }
-  return {
-    ...rest,
-    headers: { ...(headers ?? {}), ...extraHeaders },
-  };
+  const { usePublishableKey = publishableDefault, authToken, ...rest } = opts ?? {};
+  const cfg: FrameRequestConfig = { ...rest };
+  if (usePublishableKey) cfg[FRAME_USE_PUBLISHABLE_KEY] = true;
+  // Pass authToken through verbatim (including '') so the interceptor — the
+  // single chokepoint that always runs — can reject an empty value loudly.
+  if (authToken !== undefined) cfg[FRAME_AUTH_TOKEN] = authToken;
+  return cfg;
 }
 
 export function withPublishableKey(opts?: RequestOptions & AxiosRequestConfig): AxiosRequestConfig {

--- a/src/client.ts
+++ b/src/client.ts
@@ -19,9 +19,30 @@ export interface ClientConfig {
 
 export interface RequestOptions {
   usePublishableKey?: boolean;
+  // Per-request bearer override (e.g. an object `client_secret` such as
+  // `ci_..._secret_...`). When present, it wins over both an active onboarding
+  // session token and the configured pk_/sk_ keys. Mirrors the per-call
+  // `client_secret` tier of the native iOS/Android auth resolvers.
+  authToken?: string;
 }
 
+// Holds the active onboarding-session bearer token (e.g. `onb_sess_...`). The
+// request interceptor closes over a single instance of this so the token can be
+// set/cleared on the live client after construction, mirroring the native iOS
+// `beginOnboardingSession`/`endOnboardingSession` model. A mutable holder (vs.
+// recreating the client) keeps every already-wired API class pointed at the
+// same auth state.
+export interface OnboardingSessionStore {
+  token: string | null;
+}
+
+export const createOnboardingSessionStore = (): OnboardingSessionStore => ({ token: null });
+
 const PUBLISHABLE_FLAG_KEY = 'X-Frame-Use-Publishable-Key';
+// Per-request bearer override, smuggled through the request config headers so it
+// rides the normal axios call path, then stripped by the interceptor before the
+// request leaves the process (just like the publishable-key flag).
+const AUTH_TOKEN_KEY = 'X-Frame-Auth-Token';
 
 // Strips the Authorization header before stashing axios's error config on
 // FrameAPIError.raw — without this, every network-layer failure would leak
@@ -35,7 +56,10 @@ function safeRawFromAxiosError(err: any): unknown {
           headers && typeof headers === 'object'
             ? Object.fromEntries(
                 Object.entries(headers as Record<string, unknown>).filter(
-                  ([k]) => k.toLowerCase() !== 'authorization' && k !== PUBLISHABLE_FLAG_KEY,
+                  ([k]) =>
+                    k.toLowerCase() !== 'authorization' &&
+                    k !== PUBLISHABLE_FLAG_KEY &&
+                    k !== AUTH_TOKEN_KEY,
                 ),
               )
             : headers;
@@ -50,7 +74,10 @@ function safeRawFromAxiosError(err: any): unknown {
   };
 }
 
-export const createApiClient = (config: ClientConfig): AxiosInstance => {
+export const createApiClient = (
+  config: ClientConfig,
+  sessionStore: OnboardingSessionStore = createOnboardingSessionStore(),
+): AxiosInstance => {
   const { apiKey, publishableKey, defaultHeaders } = config;
 
   if (!apiKey && !publishableKey) {
@@ -73,10 +100,20 @@ export const createApiClient = (config: ClientConfig): AxiosInstance => {
       ? headers.has(PUBLISHABLE_FLAG_KEY)
       : Boolean((headers as Record<string, unknown> | undefined)?.[PUBLISHABLE_FLAG_KEY]);
 
+    const perRequestAuthToken = headers instanceof AxiosHeaders
+      ? (headers.get(AUTH_TOKEN_KEY) as string | undefined)
+      : ((headers as Record<string, unknown> | undefined)?.[AUTH_TOKEN_KEY] as string | undefined);
+
     if (headers instanceof AxiosHeaders) {
       headers.delete(PUBLISHABLE_FLAG_KEY);
-    } else if (headers && PUBLISHABLE_FLAG_KEY in (headers as Record<string, unknown>)) {
-      delete (headers as Record<string, unknown>)[PUBLISHABLE_FLAG_KEY];
+      headers.delete(AUTH_TOKEN_KEY);
+    } else if (headers) {
+      if (PUBLISHABLE_FLAG_KEY in (headers as Record<string, unknown>)) {
+        delete (headers as Record<string, unknown>)[PUBLISHABLE_FLAG_KEY];
+      }
+      if (AUTH_TOKEN_KEY in (headers as Record<string, unknown>)) {
+        delete (headers as Record<string, unknown>)[AUTH_TOKEN_KEY];
+      }
     }
 
     if (defaultHeaders) {
@@ -91,21 +128,35 @@ export const createApiClient = (config: ClientConfig): AxiosInstance => {
       }
     }
 
-    const keyToUse = wantsPublishable ? publishableKey : apiKey;
-    if (!keyToUse) {
-      throw new FrameAPIError(
-        wantsPublishable
-          ? 'Frame publishable key is not configured. Pass { publishableKey } to new FrameSDK(...) before calling endpoints with { usePublishableKey: true }.'
-          : 'Frame API key is not configured. Pass { apiKey } to new FrameSDK(...) before calling secret-keyed endpoints.',
-        wantsPublishable ? 'missing_publishable_key' : 'missing_api_key',
-        0,
-        null,
-      );
+    // Resolve the bearer with the same three-tier precedence as the native
+    // iOS/Android `bearerToken()`:
+    //   1. per-request authToken (an object client_secret), else
+    //   2. active onboarding-session token, else
+    //   3. publishableKey when usePublishableKey === true, else apiKey.
+    const sessionToken = sessionStore.token;
+    let bearer: string | undefined;
+    if (perRequestAuthToken) {
+      bearer = perRequestAuthToken;
+    } else if (sessionToken) {
+      bearer = sessionToken;
+    } else {
+      const keyToUse = wantsPublishable ? publishableKey : apiKey;
+      if (!keyToUse) {
+        throw new FrameAPIError(
+          wantsPublishable
+            ? 'Frame publishable key is not configured. Pass { publishableKey } to new FrameSDK(...) before calling endpoints with { usePublishableKey: true }.'
+            : 'Frame API key is not configured. Pass { apiKey } to new FrameSDK(...) before calling secret-keyed endpoints.',
+          wantsPublishable ? 'missing_publishable_key' : 'missing_api_key',
+          0,
+          null,
+        );
+      }
+      bearer = keyToUse;
     }
     if (headers instanceof AxiosHeaders) {
-      headers.set('Authorization', `Bearer ${keyToUse}`);
+      headers.set('Authorization', `Bearer ${bearer}`);
     } else if (headers) {
-      (headers as Record<string, string>)['Authorization'] = `Bearer ${keyToUse}`;
+      (headers as Record<string, string>)['Authorization'] = `Bearer ${bearer}`;
     }
     return requestConfig;
   });
@@ -129,24 +180,32 @@ export const createApiClient = (config: ClientConfig): AxiosInstance => {
   return client;
 };
 
-export function withPublishableKey(opts?: RequestOptions & AxiosRequestConfig): AxiosRequestConfig {
-  const { usePublishableKey = true, headers, ...rest } = opts ?? {};
-  if (!usePublishableKey) {
+// Translates RequestOptions into the internal smuggle-headers that the request
+// interceptor understands: the publishable-key routing flag and the per-request
+// authToken override. `publishableDefault` differs between the two public
+// helpers (withPublishableKey opts in by default, maybePublishableKey opts out).
+function buildRequestConfig(
+  publishableDefault: boolean,
+  opts?: RequestOptions & AxiosRequestConfig,
+): AxiosRequestConfig {
+  const { usePublishableKey = publishableDefault, authToken, headers, ...rest } = opts ?? {};
+  const extraHeaders: Record<string, string> = {};
+  if (usePublishableKey) extraHeaders[PUBLISHABLE_FLAG_KEY] = '1';
+  if (authToken) extraHeaders[AUTH_TOKEN_KEY] = authToken;
+
+  if (Object.keys(extraHeaders).length === 0) {
     return headers ? { ...rest, headers } : { ...rest };
   }
   return {
     ...rest,
-    headers: { ...(headers ?? {}), [PUBLISHABLE_FLAG_KEY]: '1' },
+    headers: { ...(headers ?? {}), ...extraHeaders },
   };
 }
 
+export function withPublishableKey(opts?: RequestOptions & AxiosRequestConfig): AxiosRequestConfig {
+  return buildRequestConfig(true, opts);
+}
+
 export function maybePublishableKey(opts?: RequestOptions & AxiosRequestConfig): AxiosRequestConfig {
-  const { usePublishableKey = false, headers, ...rest } = opts ?? {};
-  if (!usePublishableKey) {
-    return headers ? { ...rest, headers } : { ...rest };
-  }
-  return {
-    ...rest,
-    headers: { ...(headers ?? {}), [PUBLISHABLE_FLAG_KEY]: '1' },
-  };
+  return buildRequestConfig(false, opts);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { createApiClient, type ClientConfig } from './client';
+import { createApiClient, createOnboardingSessionStore, type ClientConfig, type OnboardingSessionStore } from './client';
 import { AccountsAPI } from './api/accounts-api';
 import { CapabilitiesAPI } from './api/capabilities-api';
 import { OnboardingSessionsAPI } from './api/onboarding_sessions-api';
@@ -41,7 +41,7 @@ import { GeoComplianceAPI } from './api/geo_compliance-api';
 export { paginate } from './utils/paginator';
 export { FrameAPIError } from './errors/frame_api_error';
 export { withPublishableKey, maybePublishableKey } from './client';
-export type { ClientConfig, RequestOptions } from './client';
+export type { ClientConfig, RequestOptions, OnboardingSessionStore } from './client';
 
 export type {
   EvervaultConfiguration,
@@ -115,8 +115,14 @@ export class FrameSDK {
   public wallet: WalletAPI;
   public geoCompliance: GeoComplianceAPI;
 
+  // Backs the active onboarding-session bearer token. Mutated in place by
+  // setOnboardingSession / clearOnboardingSession so every wired API class keeps
+  // sending the same auth without rebuilding the client.
+  private onboardingSessionStore: OnboardingSessionStore;
+
   constructor(config: ClientConfig) {
-    const client = createApiClient(config);
+    this.onboardingSessionStore = createOnboardingSessionStore();
+    const client = createApiClient(config, this.onboardingSessionStore);
     this.accounts = new AccountsAPI(client);
     this.capabilities = new CapabilitiesAPI(client);
     this.onboardingSessions = new OnboardingSessionsAPI(client);
@@ -155,5 +161,36 @@ export class FrameSDK {
     this.deviceAttestation = new DeviceAttestationAPI(client);
     this.wallet = new WalletAPI(client);
     this.geoCompliance = new GeoComplianceAPI(client);
+  }
+
+  /**
+   * Begin an onboarding session. While a session is active, every request sends
+   * `Authorization: Bearer <token>` (e.g. an `onb_sess_...` token), overriding
+   * the configured publishable/secret keys regardless of `usePublishableKey`.
+   * A per-request `authToken` (object client_secret) still takes precedence.
+   *
+   * Mirrors the native iOS `beginOnboardingSession`.
+   */
+  setOnboardingSession(token: string): void {
+    this.onboardingSessionStore.token = token;
+  }
+
+  /**
+   * End the active onboarding session, reverting auth to the configured
+   * publishable/secret keys.
+   *
+   * Safe-clear: when `token` is provided, the session is cleared only if it
+   * matches the currently active token. This mirrors Android's guarded
+   * teardown so a stale unmount cannot wipe a newer session. Omit `token` to
+   * force-clear unconditionally.
+   *
+   * @returns true if a session was cleared, false if the guard prevented it.
+   */
+  clearOnboardingSession(token?: string): boolean {
+    if (token !== undefined && this.onboardingSessionStore.token !== token) {
+      return false;
+    }
+    this.onboardingSessionStore.token = null;
+    return true;
   }
 }

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,7 +1,12 @@
 /// <reference types="jest" />
 
 import nock from 'nock';
-import { createApiClient, withPublishableKey, maybePublishableKey } from '../src/client';
+import {
+  createApiClient,
+  createOnboardingSessionStore,
+  withPublishableKey,
+  maybePublishableKey,
+} from '../src/client';
 import { FrameAPIError } from '../src/errors/frame_api_error';
 import { FrameSDK } from '../src';
 
@@ -101,6 +106,23 @@ describe('withPublishableKey / maybePublishableKey helpers', () => {
     const cfg = withPublishableKey({ usePublishableKey: false, headers: { 'X-Trace-Id': 'abc' } });
     expect((cfg.headers as Record<string, string>)['X-Trace-Id']).toBe('abc');
     expect((cfg.headers as Record<string, string>)['X-Frame-Use-Publishable-Key']).toBeUndefined();
+  });
+
+  test('maybePublishableKey threads authToken into the smuggle header', () => {
+    const cfg = maybePublishableKey({ authToken: 'ci_1_secret_x' });
+    expect((cfg.headers as Record<string, string>)['X-Frame-Auth-Token']).toBe('ci_1_secret_x');
+    expect((cfg.headers as Record<string, string>)['X-Frame-Use-Publishable-Key']).toBeUndefined();
+  });
+
+  test('authToken and usePublishableKey can be combined and both ride through', () => {
+    const cfg = maybePublishableKey({ authToken: 'ci_1_secret_x', usePublishableKey: true });
+    expect((cfg.headers as Record<string, string>)['X-Frame-Auth-Token']).toBe('ci_1_secret_x');
+    expect((cfg.headers as Record<string, string>)['X-Frame-Use-Publishable-Key']).toBe('1');
+  });
+
+  test('no authToken means no smuggle header', () => {
+    const cfg = maybePublishableKey();
+    expect(cfg.headers).toBeUndefined();
   });
 });
 
@@ -261,6 +283,123 @@ describe('baseURL override', () => {
 
     const customer = await frame.customers.get('cust_123');
     expect(customer.id).toBe('cust_123');
+  });
+});
+
+describe('bearer auth precedence — authToken > session > pk/sk', () => {
+  test('per-request authToken (client_secret) wins over pk/sk and is sent verbatim', async () => {
+    const client = createApiClient({ apiKey: 'sk_test', publishableKey: 'pk_test' });
+
+    nock(baseUrl, {
+      reqheaders: { authorization: 'Bearer ci_123_secret_abc' },
+    })
+      .post('/v1/charge_intents/ci_123/confirm')
+      .reply(200, { id: 'ci_123' });
+
+    await client.post('/v1/charge_intents/ci_123/confirm', undefined, maybePublishableKey({ authToken: 'ci_123_secret_abc' }));
+  });
+
+  test('per-request authToken wins over an active onboarding session token', async () => {
+    const store = createOnboardingSessionStore();
+    store.token = 'onb_sess_live';
+    const client = createApiClient({ apiKey: 'sk_test', publishableKey: 'pk_test' }, store);
+
+    nock(baseUrl, {
+      reqheaders: { authorization: 'Bearer ci_123_secret_abc' },
+    })
+      .post('/v1/charge_intents/ci_123/confirm')
+      .reply(200, { id: 'ci_123' });
+
+    await client.post('/v1/charge_intents/ci_123/confirm', undefined, maybePublishableKey({ authToken: 'ci_123_secret_abc' }));
+  });
+
+  test('active onboarding session token wins over pk/sk for all calls, ignoring usePublishableKey', async () => {
+    const store = createOnboardingSessionStore();
+    store.token = 'onb_sess_live';
+    const client = createApiClient({ apiKey: 'sk_test', publishableKey: 'pk_test' }, store);
+
+    // Default routing (would be sk) -> session token.
+    nock(baseUrl, { reqheaders: { authorization: 'Bearer onb_sess_live' } })
+      .get('/v1/customers')
+      .reply(200, { data: [] });
+    // usePublishableKey routing (would be pk) -> still session token.
+    nock(baseUrl, { reqheaders: { authorization: 'Bearer onb_sess_live' } })
+      .get('/v1/config/evervault')
+      .reply(200, {});
+
+    await client.get('/v1/customers');
+    await client.get('/v1/config/evervault', withPublishableKey());
+  });
+
+  test('falls back to pk/sk when no session token and no authToken', async () => {
+    const store = createOnboardingSessionStore();
+    const client = createApiClient({ apiKey: 'sk_test', publishableKey: 'pk_test' }, store);
+
+    nock(baseUrl, { reqheaders: { authorization: 'Bearer sk_test' } })
+      .get('/v1/customers')
+      .reply(200, { data: [] });
+
+    await client.get('/v1/customers');
+  });
+
+  test('session token is sent even on a publishable-key-only client', async () => {
+    const store = createOnboardingSessionStore();
+    store.token = 'onb_sess_live';
+    const client = createApiClient({ publishableKey: 'pk_only' }, store);
+
+    nock(baseUrl, { reqheaders: { authorization: 'Bearer onb_sess_live' } })
+      .get('/v1/customers')
+      .reply(200, { data: [] });
+
+    // No api key configured, but the session token covers the request.
+    await client.get('/v1/customers');
+  });
+
+  test('the X-Frame-Auth-Token smuggle header is stripped before the request is sent', async () => {
+    const client = createApiClient({ apiKey: 'sk_test' });
+
+    nock(baseUrl)
+      .matchHeader('X-Frame-Auth-Token', (val: string | undefined) => val === undefined)
+      .post('/v1/charge_intents/ci_1/confirm')
+      .reply(200, {});
+
+    await client.post('/v1/charge_intents/ci_1/confirm', undefined, maybePublishableKey({ authToken: 'ci_1_secret_x' }));
+  });
+
+  test('clearing the session store mid-life reverts to pk/sk', async () => {
+    const store = createOnboardingSessionStore();
+    store.token = 'onb_sess_live';
+    const client = createApiClient({ apiKey: 'sk_test', publishableKey: 'pk_test' }, store);
+
+    nock(baseUrl, { reqheaders: { authorization: 'Bearer onb_sess_live' } })
+      .get('/v1/customers')
+      .reply(200, { data: [] });
+    await client.get('/v1/customers');
+
+    store.token = null;
+    nock(baseUrl, { reqheaders: { authorization: 'Bearer sk_test' } })
+      .get('/v1/customers')
+      .reply(200, { data: [] });
+    await client.get('/v1/customers');
+  });
+});
+
+describe('authToken smuggle does not leak on error.raw', () => {
+  test('network-layer FrameAPIError.raw does NOT leak the per-request authToken', async () => {
+    const client = createApiClient({ apiKey: 'sk_test', publishableKey: 'pk_test' });
+
+    nock.disableNetConnect();
+    try {
+      await client.post('/v1/charge_intents/ci_1/confirm', undefined, maybePublishableKey({ authToken: 'ci_1_secret_LEAK' }));
+      fail('expected request to reject');
+    } catch (err) {
+      const raw = JSON.stringify((err as FrameAPIError).raw);
+      expect(raw).not.toContain('ci_1_secret_LEAK');
+      expect(raw).not.toContain('X-Frame-Auth-Token');
+      expect(raw).not.toContain('Bearer');
+    } finally {
+      nock.enableNetConnect();
+    }
   });
 });
 

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -63,10 +63,12 @@ describe('createApiClient — key routing', () => {
     expect(() => createApiClient({})).toThrow(/at least one of/);
   });
 
-  test('strips the publishable flag header before sending', async () => {
+  test('publishable routing never leaks as an HTTP header', async () => {
     const client = createApiClient({ apiKey: 'sk_test', publishableKey: 'pk_test' });
 
-    nock(baseUrl)
+    // Routing is carried on the axios config, not a header — the request that
+    // hits the wire must not carry any X-Frame-Use-Publishable-Key header.
+    nock(baseUrl, { reqheaders: { authorization: 'Bearer pk_test' } })
       .matchHeader('X-Frame-Use-Publishable-Key', (val: string | undefined) => val === undefined)
       .post('/v1/config/evervault')
       .reply(200, {});
@@ -76,53 +78,56 @@ describe('createApiClient — key routing', () => {
 });
 
 describe('withPublishableKey / maybePublishableKey helpers', () => {
-  test('withPublishableKey adds the routing header by default', () => {
-    const cfg = withPublishableKey();
-    expect((cfg.headers as Record<string, string>)['X-Frame-Use-Publishable-Key']).toBe('1');
-  });
+  // Routing now rides on axios config fields (frameUsePublishableKey /
+  // frameAuthToken), never on HTTP headers — so callers can't spoof routing with
+  // a raw header and a secret authToken can't leak onto the wire.
+  type FrameCfg = Record<string, unknown>;
 
-  test('withPublishableKey({ usePublishableKey: false }) omits the routing header', () => {
-    const cfg = withPublishableKey({ usePublishableKey: false });
+  test('withPublishableKey sets frameUsePublishableKey by default', () => {
+    const cfg = withPublishableKey() as FrameCfg;
+    expect(cfg.frameUsePublishableKey).toBe(true);
     expect(cfg.headers).toBeUndefined();
   });
 
-  test('maybePublishableKey defaults to no routing header', () => {
-    const cfg = maybePublishableKey();
-    expect(cfg.headers).toBeUndefined();
+  test('withPublishableKey({ usePublishableKey: false }) omits the routing flag', () => {
+    const cfg = withPublishableKey({ usePublishableKey: false }) as FrameCfg;
+    expect(cfg.frameUsePublishableKey).toBeUndefined();
+  });
+
+  test('maybePublishableKey defaults to no routing flag', () => {
+    const cfg = maybePublishableKey() as FrameCfg;
+    expect(cfg.frameUsePublishableKey).toBeUndefined();
   });
 
   test('maybePublishableKey({ usePublishableKey: true }) opts in', () => {
-    const cfg = maybePublishableKey({ usePublishableKey: true });
-    expect((cfg.headers as Record<string, string>)['X-Frame-Use-Publishable-Key']).toBe('1');
+    const cfg = maybePublishableKey({ usePublishableKey: true }) as FrameCfg;
+    expect(cfg.frameUsePublishableKey).toBe(true);
   });
 
-  test('helpers preserve user-supplied headers', () => {
-    const cfg = withPublishableKey({ headers: { 'X-Trace-Id': 'abc' } });
-    expect((cfg.headers as Record<string, string>)['X-Trace-Id']).toBe('abc');
-    expect((cfg.headers as Record<string, string>)['X-Frame-Use-Publishable-Key']).toBe('1');
-  });
-
-  test('withPublishableKey({ usePublishableKey: false }) preserves user headers', () => {
-    const cfg = withPublishableKey({ usePublishableKey: false, headers: { 'X-Trace-Id': 'abc' } });
+  test('helpers preserve user-supplied headers and do not put routing on them', () => {
+    const cfg = withPublishableKey({ headers: { 'X-Trace-Id': 'abc' } }) as FrameCfg;
     expect((cfg.headers as Record<string, string>)['X-Trace-Id']).toBe('abc');
     expect((cfg.headers as Record<string, string>)['X-Frame-Use-Publishable-Key']).toBeUndefined();
+    expect(cfg.frameUsePublishableKey).toBe(true);
   });
 
-  test('maybePublishableKey threads authToken into the smuggle header', () => {
-    const cfg = maybePublishableKey({ authToken: 'ci_1_secret_x' });
-    expect((cfg.headers as Record<string, string>)['X-Frame-Auth-Token']).toBe('ci_1_secret_x');
-    expect((cfg.headers as Record<string, string>)['X-Frame-Use-Publishable-Key']).toBeUndefined();
-  });
-
-  test('authToken and usePublishableKey can be combined and both ride through', () => {
-    const cfg = maybePublishableKey({ authToken: 'ci_1_secret_x', usePublishableKey: true });
-    expect((cfg.headers as Record<string, string>)['X-Frame-Auth-Token']).toBe('ci_1_secret_x');
-    expect((cfg.headers as Record<string, string>)['X-Frame-Use-Publishable-Key']).toBe('1');
-  });
-
-  test('no authToken means no smuggle header', () => {
-    const cfg = maybePublishableKey();
+  test('maybePublishableKey threads authToken into the frameAuthToken config field', () => {
+    const cfg = maybePublishableKey({ authToken: 'ci_1_secret_x' }) as FrameCfg;
+    expect(cfg.frameAuthToken).toBe('ci_1_secret_x');
+    expect(cfg.frameUsePublishableKey).toBeUndefined();
+    // Never on headers.
     expect(cfg.headers).toBeUndefined();
+  });
+
+  test('authToken and usePublishableKey can be combined and both ride on config', () => {
+    const cfg = maybePublishableKey({ authToken: 'ci_1_secret_x', usePublishableKey: true }) as FrameCfg;
+    expect(cfg.frameAuthToken).toBe('ci_1_secret_x');
+    expect(cfg.frameUsePublishableKey).toBe(true);
+  });
+
+  test('no authToken means no frameAuthToken field', () => {
+    const cfg = maybePublishableKey() as FrameCfg;
+    expect(cfg.frameAuthToken).toBeUndefined();
   });
 });
 
@@ -355,10 +360,11 @@ describe('bearer auth precedence — authToken > session > pk/sk', () => {
     await client.get('/v1/customers');
   });
 
-  test('the X-Frame-Auth-Token smuggle header is stripped before the request is sent', async () => {
+  test('authToken rides on config, never on the wire as a header', async () => {
     const client = createApiClient({ apiKey: 'sk_test' });
 
-    nock(baseUrl)
+    // The client_secret is the bearer, but no X-Frame-Auth-Token header is sent.
+    nock(baseUrl, { reqheaders: { authorization: 'Bearer ci_1_secret_x' } })
       .matchHeader('X-Frame-Auth-Token', (val: string | undefined) => val === undefined)
       .post('/v1/charge_intents/ci_1/confirm')
       .reply(200, {});
@@ -381,6 +387,66 @@ describe('bearer auth precedence — authToken > session > pk/sk', () => {
       .get('/v1/customers')
       .reply(200, { data: [] });
     await client.get('/v1/customers');
+  });
+});
+
+describe('routing cannot be spoofed or leaked via headers (regression)', () => {
+  test('a raw caller-supplied X-Frame-Auth-Token header does NOT become the bearer', async () => {
+    const client = createApiClient({ apiKey: 'sk_real', publishableKey: 'pk_real' });
+
+    // Pre-refactor this header overrode the bearer. It must now be inert: the
+    // configured key wins and the header is just an ordinary forwarded header.
+    nock(baseUrl, { reqheaders: { authorization: 'Bearer sk_real' } })
+      .get('/v1/customers')
+      .reply(200, { data: [] });
+
+    await client.get('/v1/customers', { headers: { 'X-Frame-Auth-Token': 'attacker_token' } });
+  });
+
+  test('a raw caller-supplied X-Frame-Use-Publishable-Key header does NOT flip routing', async () => {
+    const client = createApiClient({ apiKey: 'sk_real', publishableKey: 'pk_real' });
+
+    nock(baseUrl, { reqheaders: { authorization: 'Bearer sk_real' } })
+      .get('/v1/customers')
+      .reply(200, { data: [] });
+
+    await client.get('/v1/customers', { headers: { 'X-Frame-Use-Publishable-Key': '1' } });
+  });
+
+  test('a frameAuthToken supplied via defaultHeaders cannot leak on the wire (it is not a header)', async () => {
+    // defaultHeaders is a header map; routing lives on config, so even a value
+    // named like the old smuggle key is just an inert forwarded header and never
+    // becomes the bearer.
+    const client = createApiClient({
+      apiKey: 'sk_real',
+      defaultHeaders: { 'X-Frame-Auth-Token': 'leaky_secret' },
+    });
+
+    nock(baseUrl, { reqheaders: { authorization: 'Bearer sk_real' } })
+      .get('/v1/customers')
+      .reply(200, { data: [] });
+
+    await client.get('/v1/customers');
+  });
+});
+
+describe('empty authToken is rejected loudly', () => {
+  test('an explicitly empty authToken throws instead of falling through to pk/sk', async () => {
+    const client = createApiClient({ apiKey: 'sk_test', publishableKey: 'pk_test' });
+
+    await expect(
+      client.post('/v1/charge_intents/ci_1/confirm', undefined, maybePublishableKey({ authToken: '' })),
+    ).rejects.toMatchObject({ code: 'invalid_auth_token' });
+  });
+
+  test('an explicitly empty authToken throws even with an active session token', async () => {
+    const store = createOnboardingSessionStore();
+    store.token = 'onb_sess_live';
+    const client = createApiClient({ apiKey: 'sk_test', publishableKey: 'pk_test' }, store);
+
+    await expect(
+      client.post('/v1/charge_intents/ci_1/confirm', undefined, maybePublishableKey({ authToken: '' })),
+    ).rejects.toMatchObject({ code: 'invalid_auth_token' });
   });
 });
 

--- a/tests/configuration.test.ts
+++ b/tests/configuration.test.ts
@@ -1,19 +1,18 @@
 /// <reference types="jest" />
 
-import axios from 'axios';
 import nock from 'nock';
+import { createApiClient } from '../src/client';
 import { ConfigurationAPI } from '../src/api/configuration-api';
 
 const baseUrl = 'https://api.framepayments.com';
-const client = axios.create({ baseURL: baseUrl });
+const client = createApiClient({ apiKey: 'sk_test', publishableKey: 'pk_test' });
 const configuration = new ConfigurationAPI(client);
 
 afterEach(() => nock.cleanAll());
 
 test('getEvervaultConfiguration → GET /v1/config/evervault (secret key by default)', async () => {
-  nock(baseUrl)
+  nock(baseUrl, { reqheaders: { authorization: 'Bearer sk_test' } })
     .get('/v1/config/evervault')
-    .matchHeader('X-Frame-Use-Publishable-Key', (val) => val === undefined)
     .reply(200, { app_id: 'app_xxx', team_id: 'team_yyy' });
 
   const result = await configuration.getEvervaultConfiguration();
@@ -21,9 +20,8 @@ test('getEvervaultConfiguration → GET /v1/config/evervault (secret key by defa
 });
 
 test('getSiftConfiguration → GET /v1/config/sift (secret key by default)', async () => {
-  nock(baseUrl)
+  nock(baseUrl, { reqheaders: { authorization: 'Bearer sk_test' } })
     .get('/v1/config/sift')
-    .matchHeader('X-Frame-Use-Publishable-Key', (val) => val === undefined)
     .reply(200, { account_id: 'sift_acc', beacon_key: 'beacon_xxx' });
 
   const result = await configuration.getSiftConfiguration();
@@ -31,9 +29,8 @@ test('getSiftConfiguration → GET /v1/config/sift (secret key by default)', asy
 });
 
 test('honors usePublishableKey: true opt-in', async () => {
-  nock(baseUrl)
+  nock(baseUrl, { reqheaders: { authorization: 'Bearer pk_test' } })
     .get('/v1/config/evervault')
-    .matchHeader('X-Frame-Use-Publishable-Key', '1')
     .reply(200, { app_id: 'a', team_id: 't' });
 
   await configuration.getEvervaultConfiguration({ usePublishableKey: true });

--- a/tests/customer_identity.test.ts
+++ b/tests/customer_identity.test.ts
@@ -1,11 +1,11 @@
 /// <reference types="jest" />
-import axios from 'axios';
 import nock from 'nock';
 import { CustomerIdentityVerificationsAPI } from '../src/api/customer_identity-api';
 import { VerificationStatus, type CustomerIdentityVerification } from '../src/types/customer_identity';
+import { createApiClient } from '../src/client';
 
 const baseUrl = 'https://api.framepayments.com';
-const client = axios.create({ baseURL: baseUrl });
+const client = createApiClient({ apiKey: 'sk_test', publishableKey: 'pk_test' });
 const identityAPI = new CustomerIdentityVerificationsAPI(client);
 
 const mockVerification: CustomerIdentityVerification = {
@@ -77,13 +77,12 @@ test('uploadIdentityDocuments (Node Buffer) → multipart POST with parts visibl
   let capturedBody: Buffer | undefined;
   let capturedContentType: string | undefined;
 
-  nock(baseUrl)
+  nock(baseUrl, { reqheaders: { authorization: 'Bearer pk_test' } })
     .post('/v1/customer_identity_verifications/civ_123/upload_documents')
     .matchHeader('content-type', (val) => {
       capturedContentType = val;
       return typeof val === 'string' && val.includes('multipart/form-data');
     })
-    .matchHeader('X-Frame-Use-Publishable-Key', '1')
     .reply(200, (_uri, requestBody) => {
       capturedBody = Buffer.isBuffer(requestBody)
         ? requestBody

--- a/tests/device_attestation.test.ts
+++ b/tests/device_attestation.test.ts
@@ -1,19 +1,18 @@
 /// <reference types="jest" />
 
-import axios from 'axios';
 import nock from 'nock';
+import { createApiClient } from '../src/client';
 import { DeviceAttestationAPI } from '../src/api/device_attestation-api';
 
 const baseUrl = 'https://api.framepayments.com';
-const client = axios.create({ baseURL: baseUrl });
+const client = createApiClient({ apiKey: 'sk_test', publishableKey: 'pk_test' });
 const attestation = new DeviceAttestationAPI(client);
 
 afterEach(() => nock.cleanAll());
 
 test('getChallenge → POST /v1/client/device_attestation/challenge', async () => {
-  nock(baseUrl)
+  nock(baseUrl, { reqheaders: { authorization: 'Bearer pk_test' } })
     .post('/v1/client/device_attestation/challenge')
-    .matchHeader('X-Frame-Use-Publishable-Key', '1')
     .reply(200, { challenge: 'nonce_xyz' });
 
   const result = await attestation.getChallenge();
@@ -27,9 +26,8 @@ test('attest → POST /v1/client/device_attestation/attest with body', async () 
     challenge: 'nonce_xyz',
   };
 
-  nock(baseUrl)
+  nock(baseUrl, { reqheaders: { authorization: 'Bearer pk_test' } })
     .post('/v1/client/device_attestation/attest', body)
-    .matchHeader('X-Frame-Use-Publishable-Key', '1')
     .reply(200, { status: 'attested', key_id: 'key_abc' });
 
   const result = await attestation.attest(body);

--- a/tests/geo_compliance.test.ts
+++ b/tests/geo_compliance.test.ts
@@ -1,11 +1,11 @@
 /// <reference types="jest" />
 
-import axios from 'axios';
 import nock from 'nock';
+import { createApiClient } from '../src/client';
 import { GeoComplianceAPI } from '../src/api/geo_compliance-api';
 
 const baseUrl = 'https://api.framepayments.com';
-const client = axios.create({ baseURL: baseUrl });
+const client = createApiClient({ apiKey: 'sk_test', publishableKey: 'pk_test' });
 const geo = new GeoComplianceAPI(client);
 
 afterEach(() => nock.cleanAll());
@@ -17,9 +17,8 @@ test('getAccountStatus → GET /v1/accounts/{id}/geo_compliance', async () => {
     evaluated_at: 1234,
   };
 
-  nock(baseUrl)
+  nock(baseUrl, { reqheaders: { authorization: 'Bearer sk_test' } })
     .get('/v1/accounts/acct_eric/geo_compliance')
-    .matchHeader('X-Frame-Use-Publishable-Key', (val) => val === undefined)
     .reply(200, body);
 
   const result = await geo.getAccountStatus('acct_eric');
@@ -27,9 +26,8 @@ test('getAccountStatus → GET /v1/accounts/{id}/geo_compliance', async () => {
 });
 
 test('honors usePublishableKey opt-in', async () => {
-  nock(baseUrl)
+  nock(baseUrl, { reqheaders: { authorization: 'Bearer pk_test' } })
     .get('/v1/accounts/acct_eric/geo_compliance')
-    .matchHeader('X-Frame-Use-Publishable-Key', '1')
     .reply(200, { status: 'clear', evaluated_at: 1 });
 
   await geo.getAccountStatus('acct_eric', { usePublishableKey: true });

--- a/tests/payment_methods.test.ts
+++ b/tests/payment_methods.test.ts
@@ -10,10 +10,10 @@ import {
   PaymentMethodStatus
 } from '../src/types/payment_methods';
 import nock from 'nock';
-import axios from 'axios';
+import { createApiClient } from '../src/client';
 
 const baseUrl = 'https://api.framepayments.com';
-const client = axios.create({ baseURL: baseUrl });
+const client = createApiClient({ apiKey: 'sk_test', publishableKey: 'pk_test' });
 const paymentMethods = new PaymentMethodsAPI(client);
 
 const mockPaymentMethod: PaymentMethod = {
@@ -188,9 +188,8 @@ test('createApplePayPaymentMethod → POST /v1/payment_methods with wallet envel
     },
   };
 
-  nock(baseUrl)
+  nock(baseUrl, { reqheaders: { authorization: 'Bearer pk_test' } })
     .post('/v1/payment_methods', (body) => body._wallet?.type === 'apple_pay')
-    .matchHeader('X-Frame-Use-Publishable-Key', '1')
     .reply(200, mockPaymentMethod);
 
   const result = await paymentMethods.createApplePayPaymentMethod(params);
@@ -212,9 +211,8 @@ test('createGooglePayPaymentMethod → POST /v1/payment_methods with wallet enve
     },
   };
 
-  nock(baseUrl)
+  nock(baseUrl, { reqheaders: { authorization: 'Bearer pk_test' } })
     .post('/v1/payment_methods', (body) => body._wallet?.type === 'google_pay')
-    .matchHeader('X-Frame-Use-Publishable-Key', '1')
     .reply(200, mockPaymentMethod);
 
   const result = await paymentMethods.createGooglePayPaymentMethod(params);
@@ -230,9 +228,8 @@ test('createCard honors usePublishableKey opt-in', async () => {
     cvc: '123',
   };
 
-  nock(baseUrl)
+  nock(baseUrl, { reqheaders: { authorization: 'Bearer pk_test' } })
     .post('/v1/payment_methods')
-    .matchHeader('X-Frame-Use-Publishable-Key', '1')
     .reply(200, mockPaymentMethod);
 
   await paymentMethods.createCard(input, { usePublishableKey: true });

--- a/tests/phone_verifications.test.ts
+++ b/tests/phone_verifications.test.ts
@@ -1,11 +1,11 @@
 /// <reference types="jest" />
 
-import axios from 'axios';
 import nock from 'nock';
+import { createApiClient } from '../src/client';
 import { PhoneVerificationsAPI } from '../src/api/phone_verifications-api';
 
 const baseUrl = 'https://api.framepayments.com';
-const client = axios.create({ baseURL: baseUrl });
+const client = createApiClient({ apiKey: 'sk_test', publishableKey: 'pk_test' });
 const phones = new PhoneVerificationsAPI(client);
 
 afterEach(() => nock.cleanAll());
@@ -40,9 +40,8 @@ test('create response surfaces prove_auth_token when present', async () => {
 });
 
 test('create honors usePublishableKey', async () => {
-  nock(baseUrl)
+  nock(baseUrl, { reqheaders: { authorization: 'Bearer pk_test' } })
     .post('/v1/accounts/acct_eric/phone_verifications')
-    .matchHeader('X-Frame-Use-Publishable-Key', '1')
     .reply(200, mockVerification);
 
   await phones.create('acct_eric', { phone_number: '+15551234567' }, { usePublishableKey: true });

--- a/tests/sdk.test.ts
+++ b/tests/sdk.test.ts
@@ -124,3 +124,101 @@ describe('FrameSDK constructor', () => {
     expect(wallet).toEqual({ processor: 'stripe' });
   });
 });
+
+describe('FrameSDK onboarding session — bearer override', () => {
+  test('setOnboardingSession routes every request through the session token, ignoring pk/sk', async () => {
+    const sdk = new FrameSDK({ publishableKey: 'pk_test' });
+    sdk.setOnboardingSession('onb_sess_abc');
+
+    nock(baseUrl, { reqheaders: { authorization: 'Bearer onb_sess_abc' } })
+      .post('/v1/onboarding_sessions')
+      .reply(200, { id: 'onb_1' });
+
+    const result = await sdk.onboardingSessions.create({} as never);
+    expect(result).toMatchObject({ id: 'onb_1' });
+  });
+
+  test('clearOnboardingSession() reverts to the publishable key', async () => {
+    const sdk = new FrameSDK({ publishableKey: 'pk_test' });
+    sdk.setOnboardingSession('onb_sess_abc');
+    expect(sdk.clearOnboardingSession()).toBe(true);
+
+    nock(baseUrl, { reqheaders: { authorization: 'Bearer pk_test' } })
+      .post('/v1/terms_of_service')
+      .reply(200, { token: 'tos_1' });
+
+    const result = await sdk.termsOfService.createToken({ usePublishableKey: true });
+    expect(result).toMatchObject({ token: 'tos_1' });
+  });
+
+  test('clearOnboardingSession(token) is a no-op when the token does not match (safe-clear)', async () => {
+    const sdk = new FrameSDK({ publishableKey: 'pk_test' });
+    sdk.setOnboardingSession('onb_sess_new');
+
+    // A stale unmount tries to clear an older session.
+    expect(sdk.clearOnboardingSession('onb_sess_old')).toBe(false);
+
+    // The newer session is still active.
+    nock(baseUrl, { reqheaders: { authorization: 'Bearer onb_sess_new' } })
+      .post('/v1/onboarding_sessions')
+      .reply(200, { id: 'onb_2' });
+
+    await sdk.onboardingSessions.create({} as never);
+  });
+
+  test('clearOnboardingSession(token) clears when the token matches', () => {
+    const sdk = new FrameSDK({ publishableKey: 'pk_test' });
+    sdk.setOnboardingSession('onb_sess_match');
+    expect(sdk.clearOnboardingSession('onb_sess_match')).toBe(true);
+    // Clearing again is a no-op (already null, provided token won't match null).
+    expect(sdk.clearOnboardingSession('onb_sess_match')).toBe(false);
+  });
+
+  test('setOnboardingSession replaces a prior session token', async () => {
+    const sdk = new FrameSDK({ publishableKey: 'pk_test' });
+    sdk.setOnboardingSession('onb_sess_1');
+    sdk.setOnboardingSession('onb_sess_2');
+
+    nock(baseUrl, { reqheaders: { authorization: 'Bearer onb_sess_2' } })
+      .post('/v1/onboarding_sessions')
+      .reply(200, { id: 'onb_3' });
+
+    await sdk.onboardingSessions.create({} as never);
+  });
+});
+
+describe('FrameSDK per-request client_secret bearer', () => {
+  test('chargeIntents.confirm sends the client_secret as bearer and wins over an active session', async () => {
+    const sdk = new FrameSDK({ publishableKey: 'pk_test' });
+    sdk.setOnboardingSession('onb_sess_abc');
+
+    nock(baseUrl, { reqheaders: { authorization: 'Bearer ci_9_secret_xyz' } })
+      .post('/v1/charge_intents/ci_9/confirm')
+      .reply(200, { id: 'ci_9' });
+
+    const result = await sdk.chargeIntents.confirm('ci_9', { authToken: 'ci_9_secret_xyz' });
+    expect(result).toMatchObject({ id: 'ci_9' });
+  });
+
+  test('chargeIntents.get accepts a per-request authToken', async () => {
+    const sdk = new FrameSDK({ publishableKey: 'pk_test' });
+
+    nock(baseUrl, { reqheaders: { authorization: 'Bearer ci_9_secret_xyz' } })
+      .get('/v1/charge_intents/ci_9')
+      .reply(200, { id: 'ci_9' });
+
+    const result = await sdk.chargeIntents.get('ci_9', { authToken: 'ci_9_secret_xyz' });
+    expect(result).toMatchObject({ id: 'ci_9' });
+  });
+
+  test('threeDS.get accepts a per-request authToken', async () => {
+    const sdk = new FrameSDK({ publishableKey: 'pk_test' });
+
+    nock(baseUrl, { reqheaders: { authorization: 'Bearer tds_secret_xyz' } })
+      .get('/v1/3ds/intents/tds_1')
+      .reply(200, { id: 'tds_1' });
+
+    const result = await sdk.threeDS.get('tds_1', { authToken: 'tds_secret_xyz' });
+    expect(result).toMatchObject({ id: 'tds_1' });
+  });
+});

--- a/tests/wallet.test.ts
+++ b/tests/wallet.test.ts
@@ -1,11 +1,11 @@
 /// <reference types="jest" />
 
-import axios from 'axios';
 import nock from 'nock';
+import { createApiClient } from '../src/client';
 import { WalletAPI } from '../src/api/wallet-api';
 
 const baseUrl = 'https://api.framepayments.com';
-const client = axios.create({ baseURL: baseUrl });
+const client = createApiClient({ apiKey: 'sk_test', publishableKey: 'pk_test' });
 const wallet = new WalletAPI(client);
 
 afterEach(() => nock.cleanAll());
@@ -18,9 +18,9 @@ test('getGooglePayConfiguration → GET /v1/client/wallet/google_pay', async () 
     processor_key: 'pk_live_xyz',
   };
 
-  nock(baseUrl)
+  // Publishable-by-default endpoint — routes via the publishable key.
+  nock(baseUrl, { reqheaders: { authorization: 'Bearer pk_test' } })
     .get('/v1/client/wallet/google_pay')
-    .matchHeader('X-Frame-Use-Publishable-Key', '1')
     .reply(200, config);
 
   const result = await wallet.getGooglePayConfiguration();


### PR DESCRIPTION
### Summary
Extended frame-node so publishable-key-only mobile clients can authenticate onboarding sessions and per-object client secrets, matching the native iOS/Android three-tier auth resolver.

### Changes
Auth core — [src/client.ts](vscode-webview://1vdlt4t8eoa4d98fb2dktgttst3lp819ce3n4ojqffps06hbjqel/src/client.ts)

- Added a mutable OnboardingSessionStore the request interceptor closes over, so the session token can be set/cleared on a live client without rebuilding it.
 - Added authToken to RequestOptions, smuggled through an internal X-Frame-Auth-Token header (consumed and stripped by the interceptor, same pattern as the publishable-key flag).
- Rewrote bearer resolution to the exact precedence: per-request authToken > active session token > publishable/secret key. The interceptor no longer unconditionally overwrites Authorization.
- Both withPublishableKey/maybePublishableKey now thread authToken; refactored their shared logic.
- Error-redaction (safeRawFromAxiosError) now also strips the new header so secrets never leak on FrameAPIError.raw.
- SDK surface — [src/index.ts](vscode-webview://1vdlt4t8eoa4d98fb2dktgttst3lp819ce3n4ojqffps06hbjqel/src/index.ts)

- setOnboardingSession(token) and clearOnboardingSession(token?) (safe-clear: only clears on omitted/matching token; returns true/false).