### PR TITLE
FRA-4516: Surface manifest generator (M1 producer)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "tsdown",
     "test": "jest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "surface:manifest": "ts-node --project scripts/tsconfig.json scripts/generate-surface-manifest.ts"
   },
   "repository": {
     "type": "git",

--- a/scripts/generate-surface-manifest.ts
+++ b/scripts/generate-surface-manifest.ts
@@ -1,0 +1,172 @@
+/**
+ * Surface manifest generator — frame-node (producer for the conformance audit).
+ *
+ * Emits the SDK's public resource/method surface as JSON per the schema pinned
+ * in frame-docs `CROSS_SDK_NAMING.md` ("Surface-manifest schema (for the
+ * audit)"):
+ *
+ *   { sdk, version, resources: { <canonicalResource>: { class, methods: [{ name, deprecated }] } } }
+ *
+ * FRA-4516 (producer half). Consumed by the conformance audit in the frame
+ * monolith (FRA-4457), which asserts every canonical non-deprecated public op
+ * resolves to a non-deprecated entry here or is on the exclusion list.
+ *
+ * Method surface = runtime reflection over an instantiated `FrameSDK` (the
+ * authoritative shape that actually ships). Deprecation = the JSDoc
+ * `@deprecated` tag read statically from src/api/*.ts, since JSDoc is erased at
+ * runtime. The two are cross-referenced by method name.
+ *
+ * Run: npm run surface:manifest   (see package.json; uses ts-node transpile-only)
+ * or:  npx ts-node --project scripts/tsconfig.json scripts/generate-surface-manifest.ts [--out <path>] [--stdout]
+ */
+
+import { readFileSync, writeFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { FrameSDK } from '../src/index';
+
+const SDK_NAME = 'frame-node';
+
+// Methods present on every API class that are not part of the public surface.
+const NON_SURFACE_METHODS = new Set(['constructor']);
+
+// Pagination convenience helpers (e.g. `iterateAllTransfers`) are not canonical
+// operations and must not count toward parity.
+const isPaginationHelper = (name: string): boolean => /^iterateAll[A-Z]/.test(name);
+
+/**
+ * node-native client property → canonical resource key (per CROSS_SDK_NAMING.md
+ * resource catalog). Only the entries that DIFFER from the client property need
+ * listing; everything else is already canonical and passes through unchanged.
+ * `customers` and `chargeIntents` are the deprecated (alias-only) resources —
+ * kept under their own key so the audit can see them and exclude them from the
+ * parity denominator via the deprecated set, not silently dropped.
+ */
+const NATIVE_TO_CANONICAL: Record<string, string> = {
+  threeDS: 'threeDsIntents',
+  // deprecated resources retain their legacy keys (excluded from parity denom):
+  customers: 'customers',
+  chargeIntents: 'chargeIntents',
+};
+
+interface MethodEntry {
+  name: string;
+  deprecated: boolean;
+}
+interface ResourceEntry {
+  class: string;
+  methods: MethodEntry[];
+}
+interface Manifest {
+  sdk: string;
+  version: string;
+  resources: Record<string, ResourceEntry>;
+}
+
+const repoRoot = join(__dirname, '..');
+
+function readPackageVersion(): string {
+  const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8'));
+  if (!pkg.version) throw new Error('package.json is missing a version');
+  return pkg.version as string;
+}
+
+/**
+ * Scan src/api/*.ts for methods carrying a JSDoc `@deprecated` tag. Returns a
+ * map of API class name → set of deprecated method names. Parsed statically
+ * because the tag does not survive to runtime.
+ */
+function collectDeprecatedMethods(): Map<string, Set<string>> {
+  const apiDir = join(repoRoot, 'src', 'api');
+  const result = new Map<string, Set<string>>();
+  for (const file of readdirSync(apiDir)) {
+    if (!file.endsWith('-api.ts')) continue;
+    const source = readFileSync(join(apiDir, file), 'utf8');
+    const classMatch = source.match(/export class (\w+API)\b/);
+    if (!classMatch) continue;
+    const className = classMatch[1];
+    const deprecated = new Set<string>();
+
+    // Walk each `@deprecated` occurrence and bind it to the next method decl.
+    const methodDecl = /(?:async\s+)?([a-zA-Z_$][\w$]*)\s*(?:<[^>]*>)?\s*\(/g;
+    let searchFrom = 0;
+    let idx = source.indexOf('@deprecated', searchFrom);
+    while (idx !== -1) {
+      methodDecl.lastIndex = idx;
+      const m = methodDecl.exec(source);
+      if (m && !NON_SURFACE_METHODS.has(m[1])) deprecated.add(m[1]);
+      searchFrom = idx + '@deprecated'.length;
+      idx = source.indexOf('@deprecated', searchFrom);
+    }
+    if (deprecated.size) result.set(className, deprecated);
+  }
+  return result;
+}
+
+function buildManifest(): Manifest {
+  const deprecatedByClass = collectDeprecatedMethods();
+
+  // A publishable key is enough to instantiate (constructor requires one of
+  // apiKey/publishableKey); no network calls are made by reflection.
+  const sdk = new FrameSDK({ publishableKey: 'pk_surface_manifest_reflection' });
+
+  const resources: Record<string, ResourceEntry> = {};
+
+  for (const prop of Object.keys(sdk)) {
+    const value = (sdk as unknown as Record<string, unknown>)[prop];
+    if (!value || typeof value !== 'object') continue;
+    const proto = Object.getPrototypeOf(value);
+    if (!proto || proto === Object.prototype) continue;
+    const className = value.constructor?.name;
+    if (!className || !/API$/.test(className)) continue;
+
+    const methods: MethodEntry[] = [];
+    for (const name of Object.getOwnPropertyNames(proto)) {
+      if (NON_SURFACE_METHODS.has(name)) continue;
+      if (isPaginationHelper(name)) continue;
+      const desc = Object.getOwnPropertyDescriptor(proto, name);
+      if (!desc || typeof desc.value !== 'function') continue; // skip getters/setters
+      methods.push({
+        name,
+        deprecated: deprecatedByClass.get(className)?.has(name) ?? false,
+      });
+    }
+    methods.sort((a, b) => a.name.localeCompare(b.name));
+
+    const canonical = NATIVE_TO_CANONICAL[prop] ?? prop;
+    resources[canonical] = { class: className, methods };
+  }
+
+  return {
+    sdk: SDK_NAME,
+    version: readPackageVersion(),
+    resources: Object.fromEntries(
+      Object.entries(resources).sort(([a], [b]) => a.localeCompare(b)),
+    ),
+  };
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const toStdout = args.includes('--stdout');
+  const outIdx = args.indexOf('--out');
+  const outPath =
+    outIdx !== -1 ? args[outIdx + 1] : join(repoRoot, 'surface-manifest.json');
+
+  const manifest = buildManifest();
+  const json = JSON.stringify(manifest, null, 2) + '\n';
+
+  if (toStdout) {
+    process.stdout.write(json);
+    return;
+  }
+  writeFileSync(outPath, json);
+  const count = Object.values(manifest.resources).reduce(
+    (n, r) => n + r.methods.length,
+    0,
+  );
+  process.stderr.write(
+    `Wrote ${outPath}: ${Object.keys(manifest.resources).length} resources, ${count} methods (v${manifest.version})\n`,
+  );
+}
+
+main();

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  // Script-local config so the surface-manifest generator runs under ts-node in
+  // CommonJS transpile-only mode. The library's root tsconfig targets ESNext
+  // modules (for the published ESM/CJS bundle); tooling scripts don't need that
+  // and CommonJS avoids the ts-node ESM-loader require-cycle friction.
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "rootDir": "..",
+    "verbatimModuleSyntax": false,
+    "isolatedModules": false,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "ts-node": {
+    "transpileOnly": true
+  },
+  "include": ["./**/*.ts", "../src/**/*.ts"]
+}

--- a/surface-manifest.json
+++ b/surface-manifest.json
@@ -1,0 +1,832 @@
+{
+  "sdk": "frame-node",
+  "version": "2.4.0",
+  "resources": {
+    "accounts": {
+      "class": "AccountsAPI",
+      "methods": [
+        {
+          "name": "create",
+          "deprecated": false
+        },
+        {
+          "name": "disable",
+          "deprecated": false
+        },
+        {
+          "name": "get",
+          "deprecated": false
+        },
+        {
+          "name": "getGeoCompliance",
+          "deprecated": false
+        },
+        {
+          "name": "getPaymentMethods",
+          "deprecated": false
+        },
+        {
+          "name": "getPlaidLinkToken",
+          "deprecated": false
+        },
+        {
+          "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "restrict",
+          "deprecated": false
+        },
+        {
+          "name": "search",
+          "deprecated": false
+        },
+        {
+          "name": "unrestrict",
+          "deprecated": false
+        },
+        {
+          "name": "update",
+          "deprecated": false
+        }
+      ]
+    },
+    "billing": {
+      "class": "BillingAPI",
+      "methods": [
+        {
+          "name": "createBillingCredit",
+          "deprecated": false
+        },
+        {
+          "name": "createBillingInvoice",
+          "deprecated": false
+        },
+        {
+          "name": "createMetering",
+          "deprecated": false
+        },
+        {
+          "name": "createMeteringEvent",
+          "deprecated": false
+        },
+        {
+          "name": "getBillingCredit",
+          "deprecated": false
+        },
+        {
+          "name": "getCustomerReport",
+          "deprecated": false
+        },
+        {
+          "name": "getEventReport",
+          "deprecated": false
+        },
+        {
+          "name": "getEventsReport",
+          "deprecated": false
+        },
+        {
+          "name": "getMetering",
+          "deprecated": false
+        },
+        {
+          "name": "getMeteringEvent",
+          "deprecated": false
+        },
+        {
+          "name": "getSubscriptionReport",
+          "deprecated": false
+        },
+        {
+          "name": "updateMetering",
+          "deprecated": false
+        },
+        {
+          "name": "updateMeteringEvent",
+          "deprecated": false
+        }
+      ]
+    },
+    "capabilities": {
+      "class": "CapabilitiesAPI",
+      "methods": [
+        {
+          "name": "disable",
+          "deprecated": false
+        },
+        {
+          "name": "get",
+          "deprecated": false
+        },
+        {
+          "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "request",
+          "deprecated": false
+        }
+      ]
+    },
+    "chargeIntents": {
+      "class": "ChargeIntentsAPI",
+      "methods": [
+        {
+          "name": "cancel",
+          "deprecated": false
+        },
+        {
+          "name": "capture",
+          "deprecated": false
+        },
+        {
+          "name": "confirm",
+          "deprecated": false
+        },
+        {
+          "name": "create",
+          "deprecated": false
+        },
+        {
+          "name": "get",
+          "deprecated": false
+        },
+        {
+          "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "update",
+          "deprecated": false
+        },
+        {
+          "name": "voidRemaining",
+          "deprecated": false
+        }
+      ]
+    },
+    "charges": {
+      "class": "ChargesAPI",
+      "methods": [
+        {
+          "name": "get",
+          "deprecated": false
+        },
+        {
+          "name": "trace",
+          "deprecated": false
+        }
+      ]
+    },
+    "chargeSessions": {
+      "class": "ChargeSessionsAPI",
+      "methods": [
+        {
+          "name": "create",
+          "deprecated": false
+        },
+        {
+          "name": "update",
+          "deprecated": false
+        }
+      ]
+    },
+    "configuration": {
+      "class": "ConfigurationAPI",
+      "methods": [
+        {
+          "name": "getEvervaultConfiguration",
+          "deprecated": false
+        },
+        {
+          "name": "getSiftConfiguration",
+          "deprecated": false
+        }
+      ]
+    },
+    "coupons": {
+      "class": "CouponsAPI",
+      "methods": [
+        {
+          "name": "create",
+          "deprecated": false
+        },
+        {
+          "name": "get",
+          "deprecated": false
+        },
+        {
+          "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "update",
+          "deprecated": false
+        }
+      ]
+    },
+    "customerIdentityVerifications": {
+      "class": "CustomerIdentityVerificationsAPI",
+      "methods": [
+        {
+          "name": "create",
+          "deprecated": false
+        },
+        {
+          "name": "createForCustomer",
+          "deprecated": false
+        },
+        {
+          "name": "get",
+          "deprecated": false
+        },
+        {
+          "name": "submitForVerification",
+          "deprecated": false
+        },
+        {
+          "name": "uploadDocuments",
+          "deprecated": false
+        },
+        {
+          "name": "uploadIdentityDocuments",
+          "deprecated": false
+        }
+      ]
+    },
+    "customers": {
+      "class": "CustomersAPI",
+      "methods": [
+        {
+          "name": "block",
+          "deprecated": false
+        },
+        {
+          "name": "create",
+          "deprecated": false
+        },
+        {
+          "name": "delete",
+          "deprecated": false
+        },
+        {
+          "name": "get",
+          "deprecated": false
+        },
+        {
+          "name": "getPaymentMethods",
+          "deprecated": false
+        },
+        {
+          "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "search",
+          "deprecated": false
+        },
+        {
+          "name": "unblock",
+          "deprecated": false
+        },
+        {
+          "name": "update",
+          "deprecated": false
+        }
+      ]
+    },
+    "deviceAttestation": {
+      "class": "DeviceAttestationAPI",
+      "methods": [
+        {
+          "name": "attest",
+          "deprecated": false
+        },
+        {
+          "name": "getChallenge",
+          "deprecated": false
+        }
+      ]
+    },
+    "discounts": {
+      "class": "DiscountsAPI",
+      "methods": [
+        {
+          "name": "get",
+          "deprecated": false
+        },
+        {
+          "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "validate",
+          "deprecated": false
+        }
+      ]
+    },
+    "disputes": {
+      "class": "DisputesAPI",
+      "methods": [
+        {
+          "name": "createDocument",
+          "deprecated": false
+        },
+        {
+          "name": "get",
+          "deprecated": false
+        },
+        {
+          "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "update",
+          "deprecated": false
+        }
+      ]
+    },
+    "geoCompliance": {
+      "class": "GeoComplianceAPI",
+      "methods": [
+        {
+          "name": "getAccountStatus",
+          "deprecated": false
+        }
+      ]
+    },
+    "geofences": {
+      "class": "GeofencesAPI",
+      "methods": [
+        {
+          "name": "list",
+          "deprecated": false
+        }
+      ]
+    },
+    "invoiceLineItems": {
+      "class": "InvoiceLineItemsAPI",
+      "methods": [
+        {
+          "name": "create",
+          "deprecated": false
+        },
+        {
+          "name": "delete",
+          "deprecated": false
+        },
+        {
+          "name": "get",
+          "deprecated": false
+        },
+        {
+          "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "update",
+          "deprecated": false
+        }
+      ]
+    },
+    "invoices": {
+      "class": "InvoicesAPI",
+      "methods": [
+        {
+          "name": "create",
+          "deprecated": false
+        },
+        {
+          "name": "delete",
+          "deprecated": false
+        },
+        {
+          "name": "get",
+          "deprecated": false
+        },
+        {
+          "name": "issue",
+          "deprecated": false
+        },
+        {
+          "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "update",
+          "deprecated": false
+        }
+      ]
+    },
+    "onboarding": {
+      "class": "OnboardingAPI",
+      "methods": [
+        {
+          "name": "create",
+          "deprecated": false
+        },
+        {
+          "name": "get",
+          "deprecated": false
+        },
+        {
+          "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "payout",
+          "deprecated": false
+        },
+        {
+          "name": "update",
+          "deprecated": false
+        }
+      ]
+    },
+    "onboardingSessions": {
+      "class": "OnboardingSessionsAPI",
+      "methods": [
+        {
+          "name": "create",
+          "deprecated": false
+        },
+        {
+          "name": "getByAccount",
+          "deprecated": false
+        }
+      ]
+    },
+    "paymentLinkSessions": {
+      "class": "PaymentLinkSessionsAPI",
+      "methods": [
+        {
+          "name": "create",
+          "deprecated": false
+        }
+      ]
+    },
+    "paymentMethods": {
+      "class": "PaymentMethodsAPI",
+      "methods": [
+        {
+          "name": "attach",
+          "deprecated": false
+        },
+        {
+          "name": "block",
+          "deprecated": false
+        },
+        {
+          "name": "connectPlaid",
+          "deprecated": false
+        },
+        {
+          "name": "connectPlaidBankAccount",
+          "deprecated": false
+        },
+        {
+          "name": "createACH",
+          "deprecated": false
+        },
+        {
+          "name": "createApplePayPaymentMethod",
+          "deprecated": false
+        },
+        {
+          "name": "createCard",
+          "deprecated": false
+        },
+        {
+          "name": "createGooglePayPaymentMethod",
+          "deprecated": false
+        },
+        {
+          "name": "detach",
+          "deprecated": false
+        },
+        {
+          "name": "get",
+          "deprecated": false
+        },
+        {
+          "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "listForCustomer",
+          "deprecated": false
+        },
+        {
+          "name": "unblock",
+          "deprecated": false
+        },
+        {
+          "name": "update",
+          "deprecated": false
+        }
+      ]
+    },
+    "payouts": {
+      "class": "PayoutsAPI",
+      "methods": [
+        {
+          "name": "create",
+          "deprecated": false
+        }
+      ]
+    },
+    "phoneVerifications": {
+      "class": "PhoneVerificationsAPI",
+      "methods": [
+        {
+          "name": "confirm",
+          "deprecated": false
+        },
+        {
+          "name": "create",
+          "deprecated": false
+        }
+      ]
+    },
+    "productPhases": {
+      "class": "ProductPhasesAPI",
+      "methods": [
+        {
+          "name": "bulkUpdate",
+          "deprecated": false
+        },
+        {
+          "name": "create",
+          "deprecated": false
+        },
+        {
+          "name": "delete",
+          "deprecated": false
+        },
+        {
+          "name": "get",
+          "deprecated": false
+        },
+        {
+          "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "update",
+          "deprecated": false
+        }
+      ]
+    },
+    "products": {
+      "class": "ProductsAPI",
+      "methods": [
+        {
+          "name": "create",
+          "deprecated": false
+        },
+        {
+          "name": "delete",
+          "deprecated": false
+        },
+        {
+          "name": "get",
+          "deprecated": false
+        },
+        {
+          "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "search",
+          "deprecated": false
+        },
+        {
+          "name": "update",
+          "deprecated": false
+        }
+      ]
+    },
+    "promotionCodes": {
+      "class": "PromotionCodesAPI",
+      "methods": [
+        {
+          "name": "create",
+          "deprecated": false
+        },
+        {
+          "name": "get",
+          "deprecated": false
+        },
+        {
+          "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "update",
+          "deprecated": false
+        }
+      ]
+    },
+    "refunds": {
+      "class": "RefundsAPI",
+      "methods": [
+        {
+          "name": "create",
+          "deprecated": false
+        },
+        {
+          "name": "get",
+          "deprecated": false
+        },
+        {
+          "name": "list",
+          "deprecated": false
+        }
+      ]
+    },
+    "sonarSessions": {
+      "class": "SonarSessionsAPI",
+      "methods": [
+        {
+          "name": "create",
+          "deprecated": false
+        },
+        {
+          "name": "update",
+          "deprecated": false
+        }
+      ]
+    },
+    "subscriptionChangeLogs": {
+      "class": "SubscriptionChangeLogsAPI",
+      "methods": [
+        {
+          "name": "list",
+          "deprecated": false
+        }
+      ]
+    },
+    "subscriptionPhases": {
+      "class": "SubscriptionPhasesAPI",
+      "methods": [
+        {
+          "name": "bulkUpdate",
+          "deprecated": false
+        },
+        {
+          "name": "create",
+          "deprecated": false
+        },
+        {
+          "name": "delete",
+          "deprecated": false
+        },
+        {
+          "name": "get",
+          "deprecated": false
+        },
+        {
+          "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "update",
+          "deprecated": false
+        }
+      ]
+    },
+    "subscriptions": {
+      "class": "SubscriptionsAPI",
+      "methods": [
+        {
+          "name": "cancel",
+          "deprecated": false
+        },
+        {
+          "name": "create",
+          "deprecated": false
+        },
+        {
+          "name": "get",
+          "deprecated": false
+        },
+        {
+          "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "search",
+          "deprecated": false
+        },
+        {
+          "name": "update",
+          "deprecated": false
+        }
+      ]
+    },
+    "termsOfService": {
+      "class": "TermsOfServiceAPI",
+      "methods": [
+        {
+          "name": "createToken",
+          "deprecated": false
+        },
+        {
+          "name": "update",
+          "deprecated": false
+        }
+      ]
+    },
+    "threeDsIntents": {
+      "class": "ThreeDSAPI",
+      "methods": [
+        {
+          "name": "create",
+          "deprecated": false
+        },
+        {
+          "name": "get",
+          "deprecated": false
+        },
+        {
+          "name": "resend",
+          "deprecated": false
+        }
+      ]
+    },
+    "transferBillingAgreements": {
+      "class": "TransferBillingAgreementsAPI",
+      "methods": [
+        {
+          "name": "create",
+          "deprecated": false
+        },
+        {
+          "name": "get",
+          "deprecated": false
+        },
+        {
+          "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "update",
+          "deprecated": false
+        }
+      ]
+    },
+    "transferFeePlans": {
+      "class": "TransferFeePlansAPI",
+      "methods": [
+        {
+          "name": "create",
+          "deprecated": false
+        },
+        {
+          "name": "get",
+          "deprecated": false
+        },
+        {
+          "name": "list",
+          "deprecated": false
+        }
+      ]
+    },
+    "transfers": {
+      "class": "TransfersAPI",
+      "methods": [
+        {
+          "name": "create",
+          "deprecated": false
+        },
+        {
+          "name": "get",
+          "deprecated": false
+        },
+        {
+          "name": "list",
+          "deprecated": false
+        }
+      ]
+    },
+    "wallet": {
+      "class": "WalletAPI",
+      "methods": [
+        {
+          "name": "getGooglePayConfiguration",
+          "deprecated": false
+        }
+      ]
+    },
+    "webhookEndpoints": {
+      "class": "WebhookEndpointsAPI",
+      "methods": [
+        {
+          "name": "list",
+          "deprecated": false
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## FRA-4516 — Surface manifest generator (M1 producer)

Adds the **producer half** of the cross-SDK conformance audit. This SDK now emits a `surface-manifest.json` describing its public resource/method surface, to the schema pinned in [`CROSS_SDK_NAMING.md`](https://github.com/Frame-Payments/frame-docs/blob/main/lib/sdk-docs-standards/CROSS_SDK_NAMING.md). The audit (FRA-4457, in the monolith) consumes all three SDKs' manifests and asserts every canonical non-deprecated op resolves in each SDK or is on the exclusion list.

### What's here
- `scripts/generate-surface-manifest.ts` — the generator
- `scripts/tsconfig.json` — script-local CJS/transpile-only config (avoids ts-node ESM-loader friction; keeps the published bundle untouched)
- `surface-manifest.json` — generated output (committed; sorted + idempotent so CI can diff it)
- `package.json` — adds `npm run surface:manifest`

### How it works
- **Runtime reflection** over an instantiated `FrameSDK`: iterates the API-class properties and reads each prototype's methods. Excludes `constructor` and `iterateAll*` paginators.
- **Canonical resource keys**: native names are mapped to canonical (`threeDS` → `threeDsIntents`). Deprecated resources (`customers`, `chargeIntents`) are retained under legacy keys so the audit can see and exclude them from the parity denominator.
- **Deprecation**: reads the JSDoc `@deprecated` tag statically (erased at runtime) to set `deprecated` per method. None exist yet — flips on automatically when M2 adds aliases.

### Output shape
```json
{ "sdk": "frame-node", "version": "2.4.0",
  "resources": { "transfers": { "class": "TransfersAPI",
    "methods": [ { "name": "create", "deprecated": false } ] } } }
```
38 resources / 159 methods.

### Notes for the audit consumer (@ryan)
- `methods[].name` is the SDK's **native** identifier (node `get`, not canonical `retrieve`) — the audit canonicalizes via the FRA-4456 caser. Deliberately not pre-canonicalized so the manifest faithfully mirrors the shipped surface.
- Please confirm the interface before FRA-4457 lands. See the FRA-4516 comment for full producer-side decisions.

### Testing
`npm run typecheck` clean. Generator is idempotent (byte-identical on re-run).

Linear: FRA-4516

🤖 Generated with [Claude Code](https://claude.com/claude-code)
