### PR TITLE
FRA-4471: Identity/onboarding/3DS + singletons parity

### DIFF
--- a/src/api/customer_identity-api.ts
+++ b/src/api/customer_identity-api.ts
@@ -19,21 +19,31 @@ export class CustomerIdentityVerificationsAPI {
     return resp.data;
   }
 
+  // POST /v1/customer_identity_verifications/{customer_id} — the documented
+  // create-for-existing-customer route (monolith
+  // customer_identity_verifications#create_from_customer). Previously posted to
+  // the undocumented /v1/customers/{id}/identity_verifications, which has no
+  // backing route; corrected here.
   async createForCustomer(
     customerId: string,
     opts?: RequestOptions,
   ): Promise<CustomerIdentityVerification> {
     const resp = await this.client.post(
-      `/v1/customers/${customerId}/identity_verifications`,
+      `/v1/customer_identity_verifications/${customerId}`,
       undefined,
       maybePublishableKey(opts),
     );
     return resp.data;
   }
 
-  async get(id: string, opts?: RequestOptions): Promise<CustomerIdentityVerification> {
+  async retrieve(id: string, opts?: RequestOptions): Promise<CustomerIdentityVerification> {
     const resp = await this.client.get(`/v1/customer_identity_verifications/${id}`, maybePublishableKey(opts));
     return resp.data;
+  }
+
+  /** @deprecated Use `retrieve` instead. Removed at v2. */
+  async get(id: string, opts?: RequestOptions): Promise<CustomerIdentityVerification> {
+    return this.retrieve(id, opts);
   }
 
   async submitForVerification(id: string, opts?: RequestOptions): Promise<CustomerIdentityVerification> {

--- a/src/api/merchant_balance-api.ts
+++ b/src/api/merchant_balance-api.ts
@@ -1,0 +1,14 @@
+import type { AxiosInstance } from 'axios';
+import type { MerchantBalance } from '../types/merchant_balance';
+import { maybePublishableKey, type RequestOptions } from '../client';
+
+export class MerchantBalanceAPI {
+  constructor(private client: AxiosInstance) {}
+
+  // GET /v1/merchant_balance — top-level singleton, no id. Returns the current
+  // balance for the authenticated merchant.
+  async retrieve(opts?: RequestOptions): Promise<MerchantBalance> {
+    const resp = await this.client.get('/v1/merchant_balance', maybePublishableKey(opts));
+    return resp.data;
+  }
+}

--- a/src/api/onboarding-api.ts
+++ b/src/api/onboarding-api.ts
@@ -21,9 +21,14 @@ export class OnboardingAPI {
     return resp.data;
   }
 
-  async get(sessionId: string): Promise<OnboardingSession> {
+  async retrieve(sessionId: string): Promise<OnboardingSession> {
     const resp = await this.client.get(`/v1/onboarding/sessions/${sessionId}`);
     return resp.data;
+  }
+
+  /** @deprecated Use `retrieve` instead. Removed at v2. */
+  async get(sessionId: string): Promise<OnboardingSession> {
+    return this.retrieve(sessionId);
   }
 
   async update(sessionId: string, params: UpdateOnboardingSessionParams): Promise<OnboardingSession> {

--- a/src/api/onboarding_sessions-api.ts
+++ b/src/api/onboarding_sessions-api.ts
@@ -1,5 +1,9 @@
 import type { AxiosInstance } from 'axios';
-import type { OnboardingSession, CreateOnboardingSessionParams } from '../types/onboarding_sessions';
+import type {
+  OnboardingSession,
+  CreateOnboardingSessionParams,
+  OnboardingSessionBootstrap,
+} from '../types/onboarding_sessions';
 import { maybePublishableKey, type RequestOptions } from '../client';
 
 export class OnboardingSessionsAPI {
@@ -10,11 +14,26 @@ export class OnboardingSessionsAPI {
     return resp.data;
   }
 
-  async getByAccount(accountId: string, opts?: RequestOptions): Promise<OnboardingSession> {
+  async list(accountId: string, opts?: RequestOptions): Promise<OnboardingSession> {
     const resp = await this.client.get('/v1/onboarding_sessions', {
       ...maybePublishableKey(opts),
       params: { account_id: accountId },
     });
+    return resp.data;
+  }
+
+  /** @deprecated Use `list` instead. Removed at v2. */
+  async getByAccount(accountId: string, opts?: RequestOptions): Promise<OnboardingSession> {
+    return this.list(accountId, opts);
+  }
+
+  // GET /v1/onboarding_sessions/bootstrap — bootstraps the embedded onboarding
+  // Web Component from a client_secret. Authenticate with the onb_sess_* token
+  // (an active onboarding session set via setOnboardingSession, or a per-request
+  // authToken). Returns session metadata, the ordered step list, and full
+  // account context in one call.
+  async bootstrap(opts?: RequestOptions): Promise<OnboardingSessionBootstrap> {
+    const resp = await this.client.get('/v1/onboarding_sessions/bootstrap', maybePublishableKey(opts));
     return resp.data;
   }
 }

--- a/src/api/three_ds-api.ts
+++ b/src/api/three_ds-api.ts
@@ -2,7 +2,11 @@ import type { AxiosInstance } from 'axios';
 import type { ThreeDSIntent, CreateThreeDSIntentParams } from '../types/three_ds';
 import { maybePublishableKey, type RequestOptions } from '../client';
 
-export class ThreeDSAPI {
+// Canonical resource base is `threeDsIntents` (see CROSS_SDK_NAMING.md — `DS`
+// is in the acronym registry). `ThreeDSAPI` is retained as a deprecated alias
+// export below for backward compatibility; both wrap the same `/v1/3ds/intents`
+// surface.
+export class ThreeDsIntentsAPI {
   constructor(private client: AxiosInstance) {}
 
   async create(params: CreateThreeDSIntentParams, opts?: RequestOptions): Promise<ThreeDSIntent> {
@@ -10,9 +14,14 @@ export class ThreeDSAPI {
     return resp.data;
   }
 
-  async get(id: string, opts?: RequestOptions): Promise<ThreeDSIntent> {
+  async retrieve(id: string, opts?: RequestOptions): Promise<ThreeDSIntent> {
     const resp = await this.client.get(`/v1/3ds/intents/${id}`, maybePublishableKey(opts));
     return resp.data;
+  }
+
+  /** @deprecated Use `retrieve` instead. Removed at v2. */
+  async get(id: string, opts?: RequestOptions): Promise<ThreeDSIntent> {
+    return this.retrieve(id, opts);
   }
 
   async resend(id: string, opts?: RequestOptions): Promise<ThreeDSIntent> {
@@ -20,3 +29,7 @@ export class ThreeDSAPI {
     return resp.data;
   }
 }
+
+/** @deprecated Use `ThreeDsIntentsAPI` (canonical `threeDsIntents`). Removed at v2. */
+export const ThreeDSAPI = ThreeDsIntentsAPI;
+export type ThreeDSAPI = ThreeDsIntentsAPI;

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,8 @@ import { DiscountsAPI } from './api/discounts-api';
 import { PaymentLinkSessionsAPI } from './api/payment_link_sessions-api';
 import { SubscriptionChangeLogsAPI } from './api/subscription_change_logs-api';
 import { BillingAPI } from './api/billing-api';
-import { ThreeDSAPI } from './api/three_ds-api';
+import { ThreeDsIntentsAPI } from './api/three_ds-api';
+import { MerchantBalanceAPI } from './api/merchant_balance-api';
 import { ProductPhasesAPI } from './api/product_phases-api';
 import { TermsOfServiceAPI } from './api/terms_of_service-api';
 import { OnboardingAPI } from './api/onboarding-api';
@@ -106,7 +107,10 @@ export class FrameSDK {
   public paymentLinkSessions: PaymentLinkSessionsAPI;
   public subscriptionChangeLogs: SubscriptionChangeLogsAPI;
   public billing: BillingAPI;
-  public threeDS: ThreeDSAPI;
+  public threeDsIntents: ThreeDsIntentsAPI;
+  /** @deprecated Use `threeDsIntents` (canonical). Removed at v2. */
+  public threeDS: ThreeDsIntentsAPI;
+  public merchantBalance: MerchantBalanceAPI;
   public productPhases: ProductPhasesAPI;
   public termsOfService: TermsOfServiceAPI;
   public onboarding: OnboardingAPI;
@@ -153,7 +157,10 @@ export class FrameSDK {
     this.paymentLinkSessions = new PaymentLinkSessionsAPI(client);
     this.subscriptionChangeLogs = new SubscriptionChangeLogsAPI(client);
     this.billing = new BillingAPI(client);
-    this.threeDS = new ThreeDSAPI(client);
+    this.threeDsIntents = new ThreeDsIntentsAPI(client);
+    // Deprecated alias — same instance, so both properties share state.
+    this.threeDS = this.threeDsIntents;
+    this.merchantBalance = new MerchantBalanceAPI(client);
     this.productPhases = new ProductPhasesAPI(client);
     this.termsOfService = new TermsOfServiceAPI(client);
     this.onboarding = new OnboardingAPI(client);

--- a/src/types/merchant_balance.ts
+++ b/src/types/merchant_balance.ts
@@ -1,17 +1,20 @@
 // GET /v1/merchant_balance — the authenticated merchant's balance (available
 // funds, reserved amounts, pending payouts). Amounts are dollars (float).
+//
+// Per the OpenAPI spec, `status` and `reason_code` are the only guaranteed
+// fields: the documented 200 is the "balance unavailable" variant (status
+// "UNAVAILABLE", reason_code "DOTS_API_ERROR"), where the balance figures are
+// absent. On a healthy response the money/metadata fields are populated. They
+// are therefore all optional and must be narrowed before use.
 export interface MerchantBalance {
-  merchant_id: string;
-  currency: string;
-  dots_balance: number;
-  available_for_payout: number;
-  reserved_amount: number;
-  pending_payouts: number;
-  last_updated_at: string | null;
-  source: string;
-  // status/reason_code are the only required fields — populated (e.g. status
-  // "UNAVAILABLE", reason_code "DOTS_API_ERROR") when the balance provider is
-  // unreachable.
   status: string;
   reason_code?: string;
+  merchant_id?: string;
+  currency?: string;
+  dots_balance?: number;
+  available_for_payout?: number;
+  reserved_amount?: number;
+  pending_payouts?: number;
+  last_updated_at?: string | null;
+  source?: string;
 }

--- a/src/types/merchant_balance.ts
+++ b/src/types/merchant_balance.ts
@@ -1,0 +1,17 @@
+// GET /v1/merchant_balance — the authenticated merchant's balance (available
+// funds, reserved amounts, pending payouts). Amounts are dollars (float).
+export interface MerchantBalance {
+  merchant_id: string;
+  currency: string;
+  dots_balance: number;
+  available_for_payout: number;
+  reserved_amount: number;
+  pending_payouts: number;
+  last_updated_at: string | null;
+  source: string;
+  // status/reason_code are the only required fields — populated (e.g. status
+  // "UNAVAILABLE", reason_code "DOTS_API_ERROR") when the balance provider is
+  // unreachable.
+  status: string;
+  reason_code?: string;
+}

--- a/src/types/onboarding_sessions.ts
+++ b/src/types/onboarding_sessions.ts
@@ -15,3 +15,12 @@ export interface CreateOnboardingSessionParams {
   steps?: string[];
   return_url?: string;
 }
+
+// Returned by GET /v1/onboarding_sessions/bootstrap: session metadata plus the
+// full account context in one payload (for the embedded onboarding component).
+export interface OnboardingSessionBootstrap extends OnboardingSession {
+  // Full account object as returned in the bootstrap payload. Left as an opaque
+  // record — the canonical Account shape lives in ../types/accounts and callers
+  // that need it can narrow.
+  account: Record<string, unknown>;
+}

--- a/tests/customer_identity.test.ts
+++ b/tests/customer_identity.test.ts
@@ -31,7 +31,16 @@ test('create identity verification', async () => {
   expect(result).toEqual(mockVerification);
 });
 
-test('get identity verification by id', async () => {
+test('retrieve identity verification by id', async () => {
+  nock(baseUrl)
+    .get('/v1/customer_identity_verifications/civ_123')
+    .reply(200, mockVerification);
+
+  const result = await identityAPI.retrieve('civ_123');
+  expect(result).toEqual(mockVerification);
+});
+
+test('get (deprecated) delegates to retrieve', async () => {
   nock(baseUrl)
     .get('/v1/customer_identity_verifications/civ_123')
     .reply(200, mockVerification);
@@ -55,9 +64,9 @@ test('upload documents for identity verification', async () => {
   expect(result).toEqual(mockVerification);
 });
 
-test('createForCustomer → POST /v1/customers/{id}/identity_verifications', async () => {
+test('createForCustomer → POST /v1/customer_identity_verifications/{customer_id}', async () => {
   nock(baseUrl)
-    .post('/v1/customers/cus_456/identity_verifications')
+    .post('/v1/customer_identity_verifications/cus_456')
     .reply(200, mockVerification);
 
   const result = await identityAPI.createForCustomer('cus_456');

--- a/tests/merchant_balance.test.ts
+++ b/tests/merchant_balance.test.ts
@@ -27,7 +27,10 @@ test('retrieve → GET /v1/merchant_balance (no id)', async () => {
 });
 
 test('retrieve surfaces an unavailable balance', async () => {
-  const unavailable = {
+  // The documented "unavailable" variant carries only status + reason_code and
+  // omits the money fields — typing it as MerchantBalance guards that the type
+  // actually permits that shape (money fields optional).
+  const unavailable: MerchantBalance = {
     status: 'UNAVAILABLE',
     reason_code: 'DOTS_API_ERROR',
   };
@@ -36,4 +39,5 @@ test('retrieve surfaces an unavailable balance', async () => {
   const result = await merchantBalance.retrieve();
   expect(result.status).toBe('UNAVAILABLE');
   expect(result.reason_code).toBe('DOTS_API_ERROR');
+  expect(result.dots_balance).toBeUndefined();
 });

--- a/tests/merchant_balance.test.ts
+++ b/tests/merchant_balance.test.ts
@@ -1,0 +1,39 @@
+import nock from 'nock';
+import axios from 'axios';
+import { MerchantBalanceAPI } from '../src/api/merchant_balance-api';
+import type { MerchantBalance } from '../src/types/merchant_balance';
+
+const baseURL = 'https://api.framepayments.com';
+const client = axios.create({ baseURL });
+const merchantBalance = new MerchantBalanceAPI(client);
+
+const mockBalance: MerchantBalance = {
+  merchant_id: 'mer_123',
+  currency: 'USD',
+  dots_balance: 50000.0,
+  available_for_payout: 40000.0,
+  reserved_amount: 5000.0,
+  pending_payouts: 5000.0,
+  last_updated_at: '2025-04-20T00:00:00Z',
+  source: 'api',
+  status: 'AVAILABLE',
+};
+
+test('retrieve → GET /v1/merchant_balance (no id)', async () => {
+  nock(baseURL).get('/v1/merchant_balance').reply(200, mockBalance);
+
+  const result = await merchantBalance.retrieve();
+  expect(result).toEqual(mockBalance);
+});
+
+test('retrieve surfaces an unavailable balance', async () => {
+  const unavailable = {
+    status: 'UNAVAILABLE',
+    reason_code: 'DOTS_API_ERROR',
+  };
+  nock(baseURL).get('/v1/merchant_balance').reply(200, unavailable);
+
+  const result = await merchantBalance.retrieve();
+  expect(result.status).toBe('UNAVAILABLE');
+  expect(result.reason_code).toBe('DOTS_API_ERROR');
+});

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -46,7 +46,14 @@ test('create onboarding session', async () => {
   expect(result).toEqual(mockSession);
 });
 
-test('get onboarding session', async () => {
+test('retrieve onboarding session', async () => {
+  nock(baseUrl).get('/v1/onboarding/sessions/onb_123').reply(200, mockSession);
+
+  const result = await onboarding.retrieve('onb_123');
+  expect(result).toEqual(mockSession);
+});
+
+test('get (deprecated) delegates to retrieve', async () => {
   nock(baseUrl).get('/v1/onboarding/sessions/onb_123').reply(200, mockSession);
 
   const result = await onboarding.get('onb_123');

--- a/tests/onboarding_sessions.test.ts
+++ b/tests/onboarding_sessions.test.ts
@@ -41,9 +41,25 @@ test('create onboarding session with steps and return_url', async () => {
   expect(result).toEqual(mockSession);
 });
 
-test('get onboarding session by account', async () => {
+test('list onboarding sessions by account', async () => {
+  nock(baseUrl).get('/v1/onboarding_sessions').query({ account_id: 'acct_123' }).reply(200, mockSession);
+
+  const result = await onboardingSessions.list('acct_123');
+  expect(result).toEqual(mockSession);
+});
+
+test('getByAccount (deprecated) delegates to list', async () => {
   nock(baseUrl).get('/v1/onboarding_sessions').query({ account_id: 'acct_123' }).reply(200, mockSession);
 
   const result = await onboardingSessions.getByAccount('acct_123');
   expect(result).toEqual(mockSession);
+});
+
+test('bootstrap → GET /v1/onboarding_sessions/bootstrap', async () => {
+  const bootstrapPayload = { ...mockSession, account: { id: 'acct_123', status: 'active' } };
+  nock(baseUrl).get('/v1/onboarding_sessions/bootstrap').reply(200, bootstrapPayload);
+
+  const result = await onboardingSessions.bootstrap();
+  expect(result).toEqual(bootstrapPayload);
+  expect(result.account).toEqual({ id: 'acct_123', status: 'active' });
 });

--- a/tests/sdk.test.ts
+++ b/tests/sdk.test.ts
@@ -42,7 +42,9 @@ describe('FrameSDK constructor', () => {
       'paymentLinkSessions',
       'subscriptionChangeLogs',
       'billing',
+      'threeDsIntents',
       'threeDS',
+      'merchantBalance',
       'productPhases',
       'termsOfService',
       'onboarding',
@@ -55,6 +57,10 @@ describe('FrameSDK constructor', () => {
     for (const name of expectedNamespaces) {
       expect((sdk as unknown as Record<string, unknown>)[name]).toBeDefined();
     }
+
+    // threeDS is a deprecated alias of the canonical threeDsIntents — same
+    // instance, so onboarding-session/auth state is shared.
+    expect(sdk.threeDS).toBe(sdk.threeDsIntents);
   });
 
   test('full SDK construction with publishable key only — secret-keyed endpoint throws missing_api_key', async () => {

--- a/tests/three_ds.test.ts
+++ b/tests/three_ds.test.ts
@@ -1,0 +1,40 @@
+import nock from 'nock';
+import axios from 'axios';
+import { ThreeDsIntentsAPI, ThreeDSAPI } from '../src/api/three_ds-api';
+import type { ThreeDSIntent } from '../src/types/three_ds';
+
+const baseURL = 'https://api.framepayments.com';
+const client = axios.create({ baseURL });
+const threeDsIntents = new ThreeDsIntentsAPI(client);
+
+const mockIntent = { id: '3ds_123', object: 'three_ds_intent', status: 'pending' } as unknown as ThreeDSIntent;
+
+afterEach(() => nock.cleanAll());
+
+test('create → POST /v1/3ds/intents', async () => {
+  nock(baseURL).post('/v1/3ds/intents').reply(201, mockIntent);
+  const result = await threeDsIntents.create({} as never);
+  expect(result).toEqual(mockIntent);
+});
+
+test('retrieve → GET /v1/3ds/intents/{id}', async () => {
+  nock(baseURL).get('/v1/3ds/intents/3ds_123').reply(200, mockIntent);
+  const result = await threeDsIntents.retrieve('3ds_123');
+  expect(result).toEqual(mockIntent);
+});
+
+test('get (deprecated) delegates to retrieve', async () => {
+  nock(baseURL).get('/v1/3ds/intents/3ds_123').reply(200, mockIntent);
+  const result = await threeDsIntents.get('3ds_123');
+  expect(result).toEqual(mockIntent);
+});
+
+test('resend → POST /v1/3ds/intents/{id}/resend', async () => {
+  nock(baseURL).post('/v1/3ds/intents/3ds_123/resend').reply(200, mockIntent);
+  const result = await threeDsIntents.resend('3ds_123');
+  expect(result).toEqual(mockIntent);
+});
+
+test('ThreeDSAPI is a deprecated alias of ThreeDsIntentsAPI', () => {
+  expect(ThreeDSAPI).toBe(ThreeDsIntentsAPI);
+});


### PR DESCRIPTION
## FRA-4471 — Identity / onboarding / 3DS + singletons parity

M2 vertical slice. Brings the identity/onboarding/3DS resource group to canonical parity and adds the net-new singletons — **additively** (`@deprecated` aliases, nothing removed). Built against the public OpenAPI spec + monolith routes.

### Net-new surface (all 3 SDKs)
- **`merchantBalance.retrieve`** → `GET /v1/merchant_balance` (new top-level singleton, no id).
- **`onboardingSessions.bootstrap`** → `GET /v1/onboarding_sessions/bootstrap` (note: a GET despite the name; auth with the `onb_sess_*` token).

### Naming convergence (additive)
- **3DS base → canonical `threeDsIntents`** (`DS` is in the acronym registry). Legacy `threeDS` / `ThreeDS` / `ThreeDSAPI` retained as `@deprecated` aliases pointing at the same surface.
- **node `get` → `retrieve`** on customerIdentityVerifications and threeDsIntents (`get` kept as `@deprecated`).
- **`onboardingSessions.getByAccount` → `list`** (node); `getByAccount` kept as `@deprecated`.

### Bugfix rolled in
- **`createForCustomer` corrected to the documented route** `POST /v1/customer_identity_verifications/{customer_id}` (the monolith `create_from_customer` action). node was posting to `/v1/customers/{id}/identity_verifications`, which has **no backing route**. Added `createForCustomer` to ruby/php on the correct path for parity.

### ⚠️ Spec discrepancy flagged (not built)
The ticket lists `customerIdentityVerifications.list` as canonical, but **no list/index endpoint exists** — the monolith exposes this resource as `only: [:create, :show]` and the public spec has no GET on the collection. So `list` was **not** added to node/php. ruby already had a `list` method calling that non-existent route (dead code that 404s); it's marked `@deprecated` here (removed at v2), not extended. Recommend correcting the ticket's canonical target.

### Tests
Full coverage added per SDK; all suites green:
- node: 186 tests, typecheck clean
- ruby: 176 tests, standardrb clean
- php: 123 tests, phpstan + cs-fixer clean

Surface manifests (FRA-4516) regenerate to the canonical set across all three; cross-SDK parity verified for merchantBalance / onboardingSessions.bootstrap / threeDsIntents / createForCustomer.

Note: `surface-manifest.json` is intentionally not included here — it's the FRA-4516 artifact and regenerates once that lands.

Linear: FRA-4471

🤖 Generated with [Claude Code](https://claude.com/claude-code)
