### PR TITLE
feat: canonical retrieve() across resources, @deprecated get()

### DIFF
--- a/src/api/accounts-api.ts
+++ b/src/api/accounts-api.ts
@@ -26,9 +26,14 @@ export class AccountsAPI {
     return resp.data;
   }
 
-  async get(id: string, opts?: RequestOptions): Promise<Account> {
+  async retrieve(id: string, opts?: RequestOptions): Promise<Account> {
     const resp = await this.client.get(`/v1/accounts/${id}`, maybePublishableKey(opts));
     return resp.data;
+  }
+
+  /** @deprecated Use `retrieve` instead. Removed at v2. */
+  async get(id: string, opts?: RequestOptions): Promise<Account> {
+    return this.retrieve(id, opts);
   }
 
   async update(id: string, params: UpdateAccountParams, opts?: RequestOptions): Promise<Account> {

--- a/src/api/capabilities-api.ts
+++ b/src/api/capabilities-api.ts
@@ -15,9 +15,14 @@ export class CapabilitiesAPI {
     return resp.data;
   }
 
-  async get(accountId: string, name: string): Promise<Capability> {
+  async retrieve(accountId: string, name: string): Promise<Capability> {
     const resp = await this.client.get(`/v1/accounts/${accountId}/capabilities/${name}`);
     return resp.data;
+  }
+
+  /** @deprecated Use `retrieve` instead. Removed at v2. */
+  async get(accountId: string, name: string): Promise<Capability> {
+    return this.retrieve(accountId, name);
   }
 
   async disable(accountId: string, name: string): Promise<Capability> {

--- a/src/api/charges-api.ts
+++ b/src/api/charges-api.ts
@@ -4,9 +4,14 @@ import type { Charge, ChargeTrace } from '../types/charges';
 export class ChargesAPI {
   constructor(private client: AxiosInstance) {}
 
-  async get(id: string): Promise<Charge> {
+  async retrieve(id: string): Promise<Charge> {
     const resp = await this.client.get(`/v1/charges/${id}`);
     return resp.data;
+  }
+
+  /** @deprecated Use `retrieve` instead. Removed at v2. */
+  async get(id: string): Promise<Charge> {
+    return this.retrieve(id);
   }
 
   async trace(id: string): Promise<ChargeTrace> {

--- a/src/api/coupons-api.ts
+++ b/src/api/coupons-api.ts
@@ -15,9 +15,14 @@ export class CouponsAPI {
     return resp.data;
   }
 
-  async get(id: string): Promise<Coupon> {
+  async retrieve(id: string): Promise<Coupon> {
     const resp = await this.client.get(`/v1/coupons/${id}`);
     return resp.data;
+  }
+
+  /** @deprecated Use `retrieve` instead. Removed at v2. */
+  async get(id: string): Promise<Coupon> {
+    return this.retrieve(id);
   }
 
   async create(params: CreateCouponParams): Promise<Coupon> {

--- a/src/api/discounts-api.ts
+++ b/src/api/discounts-api.ts
@@ -14,9 +14,14 @@ export class DiscountsAPI {
     return resp.data;
   }
 
-  async get(id: string): Promise<Discount> {
+  async retrieve(id: string): Promise<Discount> {
     const resp = await this.client.get(`/v1/discounts/${id}`);
     return resp.data;
+  }
+
+  /** @deprecated Use `retrieve` instead. Removed at v2. */
+  async get(id: string): Promise<Discount> {
+    return this.retrieve(id);
   }
 
   async validate(params: ValidateDiscountsParams): Promise<Discount[]> {

--- a/src/api/disputes-api.ts
+++ b/src/api/disputes-api.ts
@@ -15,9 +15,14 @@ export class DisputesAPI {
     return resp.data;
   }
 
-  async get(id: string): Promise<Dispute> {
+  async retrieve(id: string): Promise<Dispute> {
     const resp = await this.client.get(`/v1/disputes/${id}`);
     return resp.data;
+  }
+
+  /** @deprecated Use `retrieve` instead. Removed at v2. */
+  async get(id: string): Promise<Dispute> {
+    return this.retrieve(id);
   }
 
   async list(per_page?: number, page?: number, charge?: string, charge_intent?: string): Promise<DisputeListResponse> {

--- a/src/api/invoice_line_item-api.ts
+++ b/src/api/invoice_line_item-api.ts
@@ -27,9 +27,14 @@ export class InvoiceLineItemsAPI {
     return resp.data;
   }
 
-  async get(invoiceId: string, lineItemId: string): Promise<InvoiceLineItem> {
+  async retrieve(invoiceId: string, lineItemId: string): Promise<InvoiceLineItem> {
     const resp = await this.client.get(`/v1/invoices/${invoiceId}/line_items/${lineItemId}`);
     return resp.data;
+  }
+
+  /** @deprecated Use `retrieve` instead. Removed at v2. */
+  async get(invoiceId: string, lineItemId: string): Promise<InvoiceLineItem> {
+    return this.retrieve(invoiceId, lineItemId);
   }
 
   async delete(invoiceId: string, lineItemId: string): Promise<DeleteInvoiceResponse> {

--- a/src/api/invoices-api.ts
+++ b/src/api/invoices-api.ts
@@ -20,9 +20,14 @@ export class InvoicesAPI {
     return resp.data;
   }
 
-  async get(id: string): Promise<Invoice> {
+  async retrieve(id: string): Promise<Invoice> {
     const resp = await this.client.get(`/v1/invoices/${id}`);
     return resp.data;
+  }
+
+  /** @deprecated Use `retrieve` instead. Removed at v2. */
+  async get(id: string): Promise<Invoice> {
+    return this.retrieve(id);
   }
 
   async list(per_page?: number, page?: number, customer?: string, status?: string): Promise<InvoiceListResponse> {

--- a/src/api/payment_methods-api.ts
+++ b/src/api/payment_methods-api.ts
@@ -49,9 +49,14 @@ export class PaymentMethodsAPI {
     return resp.data;
   }
 
-  async get(id: string): Promise<PaymentMethod> {
+  async retrieve(id: string): Promise<PaymentMethod> {
     const resp = await this.client.get(`/v1/payment_methods/${id}`);
     return resp.data;
+  }
+
+  /** @deprecated Use `retrieve` instead. Removed at v2. */
+  async get(id: string): Promise<PaymentMethod> {
+    return this.retrieve(id);
   }
 
   async list(per_page?: number, page?: number): Promise<PaymentMethodListResponse> {

--- a/src/api/product_phases-api.ts
+++ b/src/api/product_phases-api.ts
@@ -15,9 +15,14 @@ export class ProductPhasesAPI {
     return resp.data;
   }
 
-  async get(productId: string, phaseId: string): Promise<ProductPhase> {
+  async retrieve(productId: string, phaseId: string): Promise<ProductPhase> {
     const resp = await this.client.get(`/v1/products/${productId}/phases/${phaseId}`);
     return resp.data;
+  }
+
+  /** @deprecated Use `retrieve` instead. Removed at v2. */
+  async get(productId: string, phaseId: string): Promise<ProductPhase> {
+    return this.retrieve(productId, phaseId);
   }
 
   async create(productId: string, params: CreateProductPhaseParams): Promise<ProductPhase> {

--- a/src/api/products-api.ts
+++ b/src/api/products-api.ts
@@ -15,9 +15,14 @@ export class ProductsAPI {
     return resp.data;
   }
 
-  async get(id: string): Promise<Product> {
+  async retrieve(id: string): Promise<Product> {
     const resp = await this.client.get(`/v1/products/${id}`);
     return resp.data;
+  }
+
+  /** @deprecated Use `retrieve` instead. Removed at v2. */
+  async get(id: string): Promise<Product> {
+    return this.retrieve(id);
   }
 
   async list(per_page?: number, page?: number): Promise<ProductListResponse> {

--- a/src/api/promotion_codes-api.ts
+++ b/src/api/promotion_codes-api.ts
@@ -15,9 +15,14 @@ export class PromotionCodesAPI {
     return resp.data;
   }
 
-  async get(id: string): Promise<PromotionCode> {
+  async retrieve(id: string): Promise<PromotionCode> {
     const resp = await this.client.get(`/v1/promotion_codes/${id}`);
     return resp.data;
+  }
+
+  /** @deprecated Use `retrieve` instead. Removed at v2. */
+  async get(id: string): Promise<PromotionCode> {
+    return this.retrieve(id);
   }
 
   async create(params: CreatePromotionCodeParams): Promise<PromotionCode> {

--- a/src/api/refunds-api.ts
+++ b/src/api/refunds-api.ts
@@ -10,9 +10,14 @@ export class RefundsAPI {
     return resp.data;
   }
 
-  async get(id: string): Promise<Refund> {
+  async retrieve(id: string): Promise<Refund> {
     const resp = await this.client.get(`/v1/refunds/${id}`);
     return resp.data;
+  }
+
+  /** @deprecated Use `retrieve` instead. Removed at v2. */
+  async get(id: string): Promise<Refund> {
+    return this.retrieve(id);
   }
 
   async list(per_page?: number, page?: number): Promise<RefundListResponse> {

--- a/src/api/subscription_phases-api.ts
+++ b/src/api/subscription_phases-api.ts
@@ -24,9 +24,14 @@ export class SubscriptionPhasesAPI {
           }, per_page);
         }
 
-  async get(subscriptionId: string, phaseId: string): Promise<SubscriptionPhase> {
+  async retrieve(subscriptionId: string, phaseId: string): Promise<SubscriptionPhase> {
     const resp = await this.client.get(`/v1/subscriptions/${subscriptionId}/phases/${phaseId}`);
     return resp.data;
+  }
+
+  /** @deprecated Use `retrieve` instead. Removed at v2. */
+  async get(subscriptionId: string, phaseId: string): Promise<SubscriptionPhase> {
+    return this.retrieve(subscriptionId, phaseId);
   }
 
   async create(subscriptionId: string, params: CreateSubscriptionPhaseParams): Promise<SubscriptionPhase> {

--- a/src/api/subscriptions-api.ts
+++ b/src/api/subscriptions-api.ts
@@ -21,9 +21,14 @@ export class SubscriptionsAPI {
     return resp.data;
   }
 
-  async get(id: string): Promise<Subscription> {
+  async retrieve(id: string): Promise<Subscription> {
     const resp = await this.client.get(`/v1/subscriptions/${id}`);
     return resp.data;
+  }
+
+  /** @deprecated Use `retrieve` instead. Removed at v2. */
+  async get(id: string): Promise<Subscription> {
+    return this.retrieve(id);
   }
 
   async list(per_page?: number, page?: number): Promise<SubscriptionListResponse> {

--- a/src/api/transfer_billing_agreements-api.ts
+++ b/src/api/transfer_billing_agreements-api.ts
@@ -15,9 +15,14 @@ export class TransferBillingAgreementsAPI {
     return resp.data;
   }
 
-  async get(id: string): Promise<TransferBillingAgreement> {
+  async retrieve(id: string): Promise<TransferBillingAgreement> {
     const resp = await this.client.get(`/v1/transfer_billing_agreements/${id}`);
     return resp.data;
+  }
+
+  /** @deprecated Use `retrieve` instead. Removed at v2. */
+  async get(id: string): Promise<TransferBillingAgreement> {
+    return this.retrieve(id);
   }
 
   async create(params: CreateTransferBillingAgreementParams): Promise<TransferBillingAgreement> {

--- a/src/api/transfer_fee_plans-api.ts
+++ b/src/api/transfer_fee_plans-api.ts
@@ -14,9 +14,14 @@ export class TransferFeePlansAPI {
     return resp.data;
   }
 
-  async get(id: string): Promise<TransferFeePlan> {
+  async retrieve(id: string): Promise<TransferFeePlan> {
     const resp = await this.client.get(`/v1/transfer_fee_plans/${id}`);
     return resp.data;
+  }
+
+  /** @deprecated Use `retrieve` instead. Removed at v2. */
+  async get(id: string): Promise<TransferFeePlan> {
+    return this.retrieve(id);
   }
 
   async create(params: CreateTransferFeePlanParams): Promise<TransferFeePlan> {

--- a/src/api/transfers-api.ts
+++ b/src/api/transfers-api.ts
@@ -11,9 +11,14 @@ export class TransfersAPI {
     return resp.data;
   }
 
-  async get(id: string): Promise<Transfer> {
+  async retrieve(id: string): Promise<Transfer> {
     const resp = await this.client.get(`/v1/transfers/${id}`);
     return resp.data;
+  }
+
+  /** @deprecated Use `retrieve` instead. Removed at v2. */
+  async get(id: string): Promise<Transfer> {
+    return this.retrieve(id);
   }
 
   async create(params: CreateTransferParams, opts?: RequestOptions): Promise<Transfer> {

--- a/surface-manifest.json
+++ b/surface-manifest.json
@@ -15,7 +15,7 @@
         },
         {
           "name": "get",
-          "deprecated": false
+          "deprecated": true
         },
         {
           "name": "getGeoCompliance",
@@ -35,6 +35,10 @@
         },
         {
           "name": "restrict",
+          "deprecated": false
+        },
+        {
+          "name": "retrieve",
           "deprecated": false
         },
         {
@@ -117,7 +121,7 @@
         },
         {
           "name": "get",
-          "deprecated": false
+          "deprecated": true
         },
         {
           "name": "list",
@@ -125,6 +129,10 @@
         },
         {
           "name": "request",
+          "deprecated": false
+        },
+        {
+          "name": "retrieve",
           "deprecated": false
         }
       ]
@@ -171,6 +179,10 @@
       "methods": [
         {
           "name": "get",
+          "deprecated": true
+        },
+        {
+          "name": "retrieve",
           "deprecated": false
         },
         {
@@ -214,10 +226,14 @@
         },
         {
           "name": "get",
-          "deprecated": false
+          "deprecated": true
         },
         {
           "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "retrieve",
           "deprecated": false
         },
         {
@@ -239,6 +255,10 @@
         },
         {
           "name": "get",
+          "deprecated": true
+        },
+        {
+          "name": "retrieve",
           "deprecated": false
         },
         {
@@ -314,10 +334,14 @@
       "methods": [
         {
           "name": "get",
-          "deprecated": false
+          "deprecated": true
         },
         {
           "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "retrieve",
           "deprecated": false
         },
         {
@@ -335,10 +359,14 @@
         },
         {
           "name": "get",
-          "deprecated": false
+          "deprecated": true
         },
         {
           "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "retrieve",
           "deprecated": false
         },
         {
@@ -378,10 +406,14 @@
         },
         {
           "name": "get",
-          "deprecated": false
+          "deprecated": true
         },
         {
           "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "retrieve",
           "deprecated": false
         },
         {
@@ -403,7 +435,7 @@
         },
         {
           "name": "get",
-          "deprecated": false
+          "deprecated": true
         },
         {
           "name": "issue",
@@ -414,7 +446,20 @@
           "deprecated": false
         },
         {
+          "name": "retrieve",
+          "deprecated": false
+        },
+        {
           "name": "update",
+          "deprecated": false
+        }
+      ]
+    },
+    "merchantBalance": {
+      "class": "MerchantBalanceAPI",
+      "methods": [
+        {
+          "name": "retrieve",
           "deprecated": false
         }
       ]
@@ -428,7 +473,7 @@
         },
         {
           "name": "get",
-          "deprecated": false
+          "deprecated": true
         },
         {
           "name": "list",
@@ -436,6 +481,10 @@
         },
         {
           "name": "payout",
+          "deprecated": false
+        },
+        {
+          "name": "retrieve",
           "deprecated": false
         },
         {
@@ -448,11 +497,19 @@
       "class": "OnboardingSessionsAPI",
       "methods": [
         {
+          "name": "bootstrap",
+          "deprecated": false
+        },
+        {
           "name": "create",
           "deprecated": false
         },
         {
           "name": "getByAccount",
+          "deprecated": true
+        },
+        {
+          "name": "list",
           "deprecated": false
         }
       ]
@@ -507,7 +564,7 @@
         },
         {
           "name": "get",
-          "deprecated": false
+          "deprecated": true
         },
         {
           "name": "list",
@@ -515,6 +572,10 @@
         },
         {
           "name": "listForCustomer",
+          "deprecated": false
+        },
+        {
+          "name": "retrieve",
           "deprecated": false
         },
         {
@@ -566,10 +627,14 @@
         },
         {
           "name": "get",
-          "deprecated": false
+          "deprecated": true
         },
         {
           "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "retrieve",
           "deprecated": false
         },
         {
@@ -591,10 +656,14 @@
         },
         {
           "name": "get",
-          "deprecated": false
+          "deprecated": true
         },
         {
           "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "retrieve",
           "deprecated": false
         },
         {
@@ -616,10 +685,14 @@
         },
         {
           "name": "get",
-          "deprecated": false
+          "deprecated": true
         },
         {
           "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "retrieve",
           "deprecated": false
         },
         {
@@ -637,10 +710,14 @@
         },
         {
           "name": "get",
-          "deprecated": false
+          "deprecated": true
         },
         {
           "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "retrieve",
           "deprecated": false
         }
       ]
@@ -684,10 +761,14 @@
         },
         {
           "name": "get",
-          "deprecated": false
+          "deprecated": true
         },
         {
           "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "retrieve",
           "deprecated": false
         },
         {
@@ -709,10 +790,14 @@
         },
         {
           "name": "get",
-          "deprecated": false
+          "deprecated": true
         },
         {
           "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "retrieve",
           "deprecated": false
         },
         {
@@ -739,7 +824,7 @@
       ]
     },
     "threeDsIntents": {
-      "class": "ThreeDSAPI",
+      "class": "ThreeDsIntentsAPI",
       "methods": [
         {
           "name": "create",
@@ -747,10 +832,14 @@
         },
         {
           "name": "get",
-          "deprecated": false
+          "deprecated": true
         },
         {
           "name": "resend",
+          "deprecated": false
+        },
+        {
+          "name": "retrieve",
           "deprecated": false
         }
       ]
@@ -764,10 +853,14 @@
         },
         {
           "name": "get",
-          "deprecated": false
+          "deprecated": true
         },
         {
           "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "retrieve",
           "deprecated": false
         },
         {
@@ -785,10 +878,14 @@
         },
         {
           "name": "get",
-          "deprecated": false
+          "deprecated": true
         },
         {
           "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "retrieve",
           "deprecated": false
         }
       ]
@@ -802,10 +899,14 @@
         },
         {
           "name": "get",
-          "deprecated": false
+          "deprecated": true
         },
         {
           "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "retrieve",
           "deprecated": false
         }
       ]
@@ -823,7 +924,27 @@
       "class": "WebhookEndpointsAPI",
       "methods": [
         {
+          "name": "create",
+          "deprecated": false
+        },
+        {
+          "name": "delete",
+          "deprecated": false
+        },
+        {
           "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "retrieve",
+          "deprecated": false
+        },
+        {
+          "name": "rotateSecret",
+          "deprecated": false
+        },
+        {
+          "name": "update",
           "deprecated": false
         }
       ]

--- a/tests/accounts.test.ts
+++ b/tests/accounts.test.ts
@@ -64,6 +64,13 @@ test('get account', async () => {
   expect(result).toEqual(mockAccount);
 });
 
+test('retrieve account', async () => {
+  nock(baseUrl).get('/v1/accounts/acct_123').reply(200, mockAccount);
+
+  const result = await accounts.retrieve('acct_123');
+  expect(result).toEqual(mockAccount);
+});
+
 test('update account', async () => {
   const updates = { metadata: { key: 'value' } };
   const updated = { ...mockAccount, ...updates };

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -42,6 +42,13 @@ test('get capability', async () => {
   expect(result).toEqual(mockCapability);
 });
 
+test('retrieve capability', async () => {
+  nock(baseUrl).get('/v1/accounts/acct_123/capabilities/card_send').reply(200, mockCapability);
+
+  const result = await capabilities.retrieve('acct_123', 'card_send');
+  expect(result).toEqual(mockCapability);
+});
+
 test('disable capability', async () => {
   nock(baseUrl).delete('/v1/accounts/acct_123/capabilities/card_send').reply(200, mockCapability);
 

--- a/tests/disputes.test.ts
+++ b/tests/disputes.test.ts
@@ -32,6 +32,15 @@ test('get dispute', async () => {
     expect(result).toEqual(mockDispute);
 });
 
+test('retrieve dispute', async () => {
+    nock(baseURL)
+        .get('/v1/disputes/dp_123')
+        .reply(200, mockDispute);
+
+    const result = await disputes.retrieve('dp_123');
+    expect(result).toEqual(mockDispute);
+});
+
 test('update dispute', async () => {
     const updates: UpdateDisputeParams = {
         submit: true

--- a/tests/invoices.test.ts
+++ b/tests/invoices.test.ts
@@ -62,6 +62,15 @@ test('get invoice', async () => {
   expect(result).toEqual(mockInvoice);
 });
 
+test('retrieve invoice', async () => {
+  nock(baseURL)
+    .get(`/v1/invoices/${mockInvoice.id}`)
+    .reply(200, mockInvoice);
+
+  const result = await invoices.retrieve(mockInvoice.id);
+  expect(result).toEqual(mockInvoice);
+});
+
 test('list invoices', async () => {
   const response = {
     meta: {

--- a/tests/payment_methods.test.ts
+++ b/tests/payment_methods.test.ts
@@ -72,6 +72,13 @@ test('get payment method', async () => {
   expect(result).toEqual(mockPaymentMethod);
 });
 
+test('retrieve payment method', async () => {
+  nock(baseUrl).get('/v1/payment_methods/pm_123').reply(200, mockPaymentMethod);
+
+  const result = await paymentMethods.retrieve('pm_123');
+  expect(result).toEqual(mockPaymentMethod);
+});
+
 test('list payment methods', async () => {
   const response = {
     data: [mockPaymentMethod],

--- a/tests/products.test.ts
+++ b/tests/products.test.ts
@@ -58,6 +58,13 @@ test('get product', async () => {
   expect(result).toEqual(mockProduct);
 });
 
+test('retrieve product', async () => {
+  nock(baseUrl).get('/v1/products/prod_123').reply(200, mockProduct);
+
+  const result = await products.retrieve('prod_123');
+  expect(result).toEqual(mockProduct);
+});
+
 test('list products', async () => {
   nock(baseUrl).get('/v1/products').query(true).reply(200, {
     data: [mockProduct],

--- a/tests/refunds.test.ts
+++ b/tests/refunds.test.ts
@@ -37,6 +37,13 @@ test('get refund', async () => {
   expect(result).toEqual(mockRefund);
 });
 
+test('retrieve refund', async () => {
+  nock(baseUrl).get('/v1/refunds/re_123').reply(200, mockRefund);
+
+  const result = await refunds.retrieve('re_123');
+  expect(result).toEqual(mockRefund);
+});
+
 test('list refunds', async () => {
   const response = {
     data: [mockRefund],

--- a/tests/subscription_phases.test.ts
+++ b/tests/subscription_phases.test.ts
@@ -47,6 +47,15 @@ test('get single phase', async () => {
   expect(result).toEqual(mockPhase);
 });
 
+test('retrieve single phase', async () => {
+  nock(baseUrl)
+    .get(`/v1/subscriptions/${subscriptionId}/phases/${phaseId}`)
+    .reply(200, mockPhase);
+
+  const result = await api.retrieve(subscriptionId, phaseId);
+  expect(result).toEqual(mockPhase);
+});
+
 test('create phase', async () => {
   const params = { start_date: 1720000000, end_date: 1720500000 };
 

--- a/tests/subscriptions.test.ts
+++ b/tests/subscriptions.test.ts
@@ -62,6 +62,13 @@ test('get subscription', async () => {
   expect(result).toEqual(mockSubscription);
 });
 
+test('retrieve subscription', async () => {
+  nock(baseUrl).get('/v1/subscriptions/sub_123').reply(200, mockSubscription);
+
+  const result = await subscriptions.retrieve('sub_123');
+  expect(result).toEqual(mockSubscription);
+});
+
 test('update subscription', async () => {
   const updates = { metadata: { updated: true } };
   const updated = { ...mockSubscription, ...updates };

--- a/tests/transfer_billing_agreements.test.ts
+++ b/tests/transfer_billing_agreements.test.ts
@@ -57,6 +57,13 @@ test('get transfer billing agreement', async () => {
   expect(result).toEqual(mockAgreement);
 });
 
+test('retrieve transfer billing agreement', async () => {
+  nock(baseUrl).get('/v1/transfer_billing_agreements/tba_123').reply(200, mockAgreement);
+
+  const result = await transferBillingAgreements.retrieve('tba_123');
+  expect(result).toEqual(mockAgreement);
+});
+
 test('update transfer billing agreement', async () => {
   const input: UpdateTransferBillingAgreementParams = { status: 'inactive' };
   const updated = { ...mockAgreement, status: 'inactive' as const };

--- a/tests/transfer_fee_plans.test.ts
+++ b/tests/transfer_fee_plans.test.ts
@@ -69,6 +69,13 @@ test('get transfer fee plan', async () => {
   expect(result).toEqual(mockFeePlan);
 });
 
+test('retrieve transfer fee plan', async () => {
+  nock(baseUrl).get('/v1/transfer_fee_plans/tfp_123').reply(200, mockFeePlan);
+
+  const result = await transferFeePlans.retrieve('tfp_123');
+  expect(result).toEqual(mockFeePlan);
+});
+
 test('list transfer fee plans', async () => {
   const response = { data: [mockFeePlan], meta: listMeta };
 

--- a/tests/transfers.test.ts
+++ b/tests/transfers.test.ts
@@ -117,6 +117,13 @@ test('get transfer', async () => {
   expect(result).toEqual(mockTransfer);
 });
 
+test('retrieve transfer', async () => {
+  nock(baseUrl).get('/v1/transfers/tr_123').reply(200, mockTransfer);
+
+  const result = await transfers.retrieve('tr_123');
+  expect(result).toEqual(mockTransfer);
+});
+
 test('list transfers', async () => {
   const response = { data: [mockTransfer], meta: listMeta };
 


### PR DESCRIPTION
The flagship node parity sweep: node was the only backend SDK using `get(id)` for retrieve-by-id (php and ruby already use `retrieve`). This converges node onto the canonical name.

## What

Across **18 API classes**, `get()` becomes `retrieve()` (byte-identical body), and `get()` stays as a thin `@deprecated` delegator (`return this.retrieve(...)`, removed at v2). Additive, zero behavior change. Mirrors the pattern already shipped on `ThreeDsIntentsAPI` and `CustomerIdentityVerificationsAPI`.

Resources: accounts, capabilities, charges, coupons, discounts, disputes, invoiceLineItems, invoices, paymentMethods, productPhases, products, promotionCodes, refunds, subscriptionPhases, subscriptions, transferBillingAgreements, transferFeePlans, transfers.

## Parity impact

Measured with the monolith `sdk_parity:audit` against the regenerated manifest:

| | before | after |
| --- | --- | --- |
| frame-node parity | 81.6% | **97.4%** |

The residual is not mechanical: `subscriptions.pause/resume` (annotated in openapi but in no SDK — a build-or-de-annotate decision) and one deprecated `onboardingSessions.getByAccount`.

## Also

Regenerates `surface-manifest.json` — which also corrects drift in the committed manifest (it lagged `main`; e.g. `customerIdentityVerifications.retrieve` was in code but missing from the checked-in JSON).

## Tests

Added `retrieve` tests mirroring existing `get` tests (nock, same assertions) for the 12 resources that had a get-by-id test; existing `get` tests retained. `npm run build` clean; `npm test` **205 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)