### PR TITLE
feat: add subscriptions.pause / resume [FRA-4467]

### DIFF
--- a/src/api/subscriptions-api.ts
+++ b/src/api/subscriptions-api.ts
@@ -54,4 +54,14 @@ export class SubscriptionsAPI {
     const resp = await this.client.post(`/v1/subscriptions/${id}/cancel`);
     return resp.data;
   }
+
+  async pause(id: string): Promise<Subscription> {
+    const resp = await this.client.post(`/v1/subscriptions/${id}/pause`);
+    return resp.data;
+  }
+
+  async resume(id: string): Promise<Subscription> {
+    const resp = await this.client.post(`/v1/subscriptions/${id}/resume`);
+    return resp.data;
+  }
 }

--- a/surface-manifest.json
+++ b/surface-manifest.json
@@ -797,6 +797,14 @@
           "deprecated": false
         },
         {
+          "name": "pause",
+          "deprecated": false
+        },
+        {
+          "name": "resume",
+          "deprecated": false
+        },
+        {
           "name": "retrieve",
           "deprecated": false
         },

--- a/tests/subscriptions.test.ts
+++ b/tests/subscriptions.test.ts
@@ -120,3 +120,17 @@ test('cancel subscription', async () => {
   const result = await subscriptions.cancel('sub_123');
   expect(result).toEqual(mockSubscription);
 });
+
+test('pause subscription', async () => {
+  nock(baseUrl).post('/v1/subscriptions/sub_123/pause').reply(200, mockSubscription);
+
+  const result = await subscriptions.pause('sub_123');
+  expect(result).toEqual(mockSubscription);
+});
+
+test('resume subscription', async () => {
+  nock(baseUrl).post('/v1/subscriptions/sub_123/resume').reply(200, mockSubscription);
+
+  const result = await subscriptions.resume('sub_123');
+  expect(result).toEqual(mockSubscription);
+});


### PR DESCRIPTION
## Summary

**AI Generated, Developer to confirm:** *Adds `subscriptions.pause(id)` and `subscriptions.resume(id)` to frame-node, wrapping the existing public `POST /v1/subscriptions/{id}/pause` and `/resume` endpoints (documented in the spec but previously unreachable from any SDK). Mirrors the existing `cancel()` pattern. Takes frame-node to 100% canonical parity.*

### Ticket Link

https://linear.app/framepayments/issue/FRA-4467

## Walkthrough Demo

TBD/Developer to provide

## How to Test

1. `npm ci && npm run build` — clean.
2. `npx jest tests/subscriptions.test.ts` — 10 tests pass (incl. new `pause` / `resume`).
3. From the monolith: `FRAME_NODE_MANIFEST=../frame-node/surface-manifest.json bundle exec rake sdk_parity:audit` — frame-node reports 100% (subscriptions.pause/resume no longer missing).