### PR TITLE
feat: canonical payment-method typed constructors [FRA-4461]

### DIFF
--- a/src/api/payment_methods-api.ts
+++ b/src/api/payment_methods-api.ts
@@ -20,12 +20,17 @@ export class PaymentMethodsAPI {
     return resp.data;
   }
 
-  async createACH(params: CreateACHPaymentMethodParams, opts?: RequestOptions): Promise<PaymentMethod> {
+  async createBankAccount(params: CreateACHPaymentMethodParams, opts?: RequestOptions): Promise<PaymentMethod> {
     const resp = await this.client.post('/v1/payment_methods', params, maybePublishableKey(opts));
     return resp.data;
   }
 
-  async createApplePayPaymentMethod(
+  /** @deprecated Use `createBankAccount` instead. Removed at v2. */
+  async createACH(params: CreateACHPaymentMethodParams, opts?: RequestOptions): Promise<PaymentMethod> {
+    return this.createBankAccount(params, opts);
+  }
+
+  async createApplePay(
     params: CreateApplePayPaymentMethodParams,
     opts?: RequestOptions,
   ): Promise<PaymentMethod> {
@@ -37,7 +42,15 @@ export class PaymentMethodsAPI {
     return resp.data;
   }
 
-  async createGooglePayPaymentMethod(
+  /** @deprecated Use `createApplePay` instead. Removed at v2. */
+  async createApplePayPaymentMethod(
+    params: CreateApplePayPaymentMethodParams,
+    opts?: RequestOptions,
+  ): Promise<PaymentMethod> {
+    return this.createApplePay(params, opts);
+  }
+
+  async createGooglePay(
     params: CreateGooglePayPaymentMethodParams,
     opts?: RequestOptions,
   ): Promise<PaymentMethod> {
@@ -47,6 +60,14 @@ export class PaymentMethodsAPI {
       maybePublishableKey({ usePublishableKey: true, ...opts }),
     );
     return resp.data;
+  }
+
+  /** @deprecated Use `createGooglePay` instead. Removed at v2. */
+  async createGooglePayPaymentMethod(
+    params: CreateGooglePayPaymentMethodParams,
+    opts?: RequestOptions,
+  ): Promise<PaymentMethod> {
+    return this.createGooglePay(params, opts);
   }
 
   async retrieve(id: string): Promise<PaymentMethod> {

--- a/surface-manifest.json
+++ b/surface-manifest.json
@@ -544,10 +544,18 @@
         },
         {
           "name": "createACH",
+          "deprecated": true
+        },
+        {
+          "name": "createApplePay",
           "deprecated": false
         },
         {
           "name": "createApplePayPaymentMethod",
+          "deprecated": true
+        },
+        {
+          "name": "createBankAccount",
           "deprecated": false
         },
         {
@@ -555,8 +563,12 @@
           "deprecated": false
         },
         {
-          "name": "createGooglePayPaymentMethod",
+          "name": "createGooglePay",
           "deprecated": false
+        },
+        {
+          "name": "createGooglePayPaymentMethod",
+          "deprecated": true
         },
         {
           "name": "detach",

--- a/tests/payment_methods.test.ts
+++ b/tests/payment_methods.test.ts
@@ -65,6 +65,19 @@ test('create ach payment method', async () => {
   expect(result).toEqual(mockACHPaymentMethod);
 });
 
+test('create bank account payment method (canonical)', async () => {
+  const input: CreateACHPaymentMethodParams = {
+      type: PaymentMethodType.ACH,
+      account_type: PaymentAccountType.CHECKING,
+      account_number: '1234567890123',
+      routing_number: '123123123'
+   };
+  nock(baseUrl).post('/v1/payment_methods').reply(200, mockACHPaymentMethod);
+
+  const result = await paymentMethods.createBankAccount(input as any);
+  expect(result).toEqual(mockACHPaymentMethod);
+});
+
 test('get payment method', async () => {
   nock(baseUrl).get('/v1/payment_methods/pm_123').reply(200, mockPaymentMethod);
 
@@ -223,6 +236,34 @@ test('createGooglePayPaymentMethod → POST /v1/payment_methods with wallet enve
     .reply(200, mockPaymentMethod);
 
   const result = await paymentMethods.createGooglePayPaymentMethod(params);
+  expect(result).toEqual(mockPaymentMethod);
+});
+
+test('createApplePay (canonical) → POST /v1/payment_methods with wallet envelope', async () => {
+  const params = {
+    type: 'card' as const,
+    customer: 'cus_abc',
+    _wallet: { type: 'apple_pay' as const, apple_pay: { requestId: 'req_1' } },
+  };
+  nock(baseUrl, { reqheaders: { authorization: 'Bearer pk_test' } })
+    .post('/v1/payment_methods', (body) => body._wallet?.type === 'apple_pay')
+    .reply(200, mockPaymentMethod);
+
+  const result = await paymentMethods.createApplePay(params as any);
+  expect(result).toEqual(mockPaymentMethod);
+});
+
+test('createGooglePay (canonical) → POST /v1/payment_methods with wallet envelope', async () => {
+  const params = {
+    type: 'card' as const,
+    account: 'acct_123',
+    _wallet: { type: 'google_pay' as const, google_pay: { apiVersion: 2 } },
+  };
+  nock(baseUrl, { reqheaders: { authorization: 'Bearer pk_test' } })
+    .post('/v1/payment_methods', (body) => body._wallet?.type === 'google_pay')
+    .reply(200, mockPaymentMethod);
+
+  const result = await paymentMethods.createGooglePay(params as any);
   expect(result).toEqual(mockPaymentMethod);
 });
 


### PR DESCRIPTION
Renames the payment-method typed constructors to their canonical names, keeping the old names as `@deprecated` delegators (removed at v2):
- `createACH` → `createBankAccount`
- `createApplePayPaymentMethod` → `createApplePay`
- `createGooglePayPaymentMethod` → `createGooglePay`
- `createCard` already canonical.

Additive — **frame-react-native calls the old names** (`createGooglePayPaymentMethod`, etc.) and keeps working via the aliases. Part of the 1→N payment-methods convergence (FRA-4461) across node/ruby/php.

Tests: 18 pass (canonical-name tests added alongside the retained deprecated-name tests). `npm run build` clean.

Related: frame-ruby + frame-php `ryan/pm-typed-constructors`, and the monolith 1→N annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)