### PR TITLE
feat: add beneficialOwners resource (FRA-4460)

### DIFF
--- a/src/api/accounts-api.ts
+++ b/src/api/accounts-api.ts
@@ -75,8 +75,11 @@ export class AccountsAPI {
     return resp.data;
   }
 
-  async getGeoCompliance(accountId: string): Promise<GeoComplianceStatus> {
-    const resp = await this.client.get(`/v1/accounts/${accountId}/geo_compliance`);
+  async getGeoCompliance(accountId: string, opts?: RequestOptions): Promise<GeoComplianceStatus> {
+    const resp = await this.client.get(
+      `/v1/accounts/${accountId}/geo_compliance`,
+      maybePublishableKey(opts),
+    );
     return resp.data;
   }
 

--- a/src/api/beneficial_owners-api.ts
+++ b/src/api/beneficial_owners-api.ts
@@ -1,0 +1,78 @@
+import type { AxiosInstance } from 'axios';
+import type { Account } from '../types/accounts';
+import type {
+  BeneficialOwner,
+  BeneficialOwnerListResponse,
+  CreateBeneficialOwnerParams,
+  UpdateBeneficialOwnerParams,
+} from '../types/beneficial_owners';
+import { maybePublishableKey, type RequestOptions } from '../client';
+
+export class BeneficialOwnersAPI {
+  constructor(private client: AxiosInstance) {}
+
+  async list(accountId: string, opts?: RequestOptions): Promise<BeneficialOwnerListResponse> {
+    const resp = await this.client.get(
+      `/v1/accounts/${accountId}/beneficial_owners`,
+      maybePublishableKey(opts),
+    );
+    return resp.data;
+  }
+
+  async create(
+    accountId: string,
+    params: CreateBeneficialOwnerParams,
+    opts?: RequestOptions,
+  ): Promise<BeneficialOwner> {
+    const resp = await this.client.post(
+      `/v1/accounts/${accountId}/beneficial_owners`,
+      params,
+      maybePublishableKey(opts),
+    );
+    return resp.data;
+  }
+
+  async retrieve(accountId: string, id: string, opts?: RequestOptions): Promise<BeneficialOwner> {
+    const resp = await this.client.get(
+      `/v1/accounts/${accountId}/beneficial_owners/${id}`,
+      maybePublishableKey(opts),
+    );
+    return resp.data;
+  }
+
+  async update(
+    accountId: string,
+    id: string,
+    params: UpdateBeneficialOwnerParams,
+    opts?: RequestOptions,
+  ): Promise<BeneficialOwner> {
+    const resp = await this.client.patch(
+      `/v1/accounts/${accountId}/beneficial_owners/${id}`,
+      params,
+      maybePublishableKey(opts),
+    );
+    return resp.data;
+  }
+
+  async delete(accountId: string, id: string): Promise<void> {
+    await this.client.delete(`/v1/accounts/${accountId}/beneficial_owners/${id}`);
+  }
+
+  async confirmRoster(accountId: string, opts?: RequestOptions): Promise<Account> {
+    const resp = await this.client.post(
+      `/v1/accounts/${accountId}/beneficial_owners/confirm`,
+      undefined,
+      maybePublishableKey(opts),
+    );
+    return resp.data;
+  }
+
+  async resendInvite(accountId: string, id: string, opts?: RequestOptions): Promise<BeneficialOwner> {
+    const resp = await this.client.post(
+      `/v1/accounts/${accountId}/beneficial_owners/${id}/resend_invite`,
+      undefined,
+      maybePublishableKey(opts),
+    );
+    return resp.data;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { createApiClient, createOnboardingSessionStore, type ClientConfig, type OnboardingSessionStore } from './client';
 import { AccountsAPI } from './api/accounts-api';
+import { BeneficialOwnersAPI } from './api/beneficial_owners-api';
 import { CapabilitiesAPI } from './api/capabilities-api';
 import { OnboardingSessionsAPI } from './api/onboarding_sessions-api';
 import { CustomersAPI } from './api/customers-api';
@@ -75,9 +76,16 @@ export type {
   NodeFilePayload,
 } from './types/customer_identity';
 export type { GeoComplianceStatus } from './types/geo_compliance';
+export type {
+  BeneficialOwner,
+  BeneficialOwnerListResponse,
+  CreateBeneficialOwnerParams,
+  UpdateBeneficialOwnerParams,
+} from './types/beneficial_owners';
 
 export class FrameSDK {
   public accounts: AccountsAPI;
+  public beneficialOwners: BeneficialOwnersAPI;
   public capabilities: CapabilitiesAPI;
   public onboardingSessions: OnboardingSessionsAPI;
   public customers: CustomersAPI;
@@ -128,6 +136,7 @@ export class FrameSDK {
     this.onboardingSessionStore = createOnboardingSessionStore();
     const client = createApiClient(config, this.onboardingSessionStore);
     this.accounts = new AccountsAPI(client);
+    this.beneficialOwners = new BeneficialOwnersAPI(client);
     this.capabilities = new CapabilitiesAPI(client);
     this.onboardingSessions = new OnboardingSessionsAPI(client);
     this.customers = new CustomersAPI(client);

--- a/src/types/beneficial_owners.ts
+++ b/src/types/beneficial_owners.ts
@@ -1,0 +1,44 @@
+export interface BeneficialOwner {
+  id: string;
+  object: string;
+  account_id: string;
+  first_name: string;
+  middle_name?: string | null;
+  last_name: string;
+  suffix?: string | null;
+  email: string;
+  roles: string[];
+  percent_ownership?: number | null;
+  status: string;
+  livemode: boolean;
+  created: number;
+  updated: number;
+}
+
+export interface BeneficialOwnerListResponse {
+  data: BeneficialOwner[];
+}
+
+export interface CreateBeneficialOwnerParams {
+  first_name: string;
+  last_name: string;
+  email: string;
+  roles: string[];
+  invite?: boolean;
+  dob?: string;
+  ssn?: string;
+  address_line1?: string;
+  city?: string;
+  state?: string;
+  postal_code?: string;
+  percent_ownership?: number;
+}
+
+export interface UpdateBeneficialOwnerParams {
+  first_name?: string;
+  last_name?: string;
+  email?: string;
+  ssn?: string;
+  roles?: string[];
+  percent_ownership?: number;
+}

--- a/surface-manifest.json
+++ b/surface-manifest.json
@@ -55,6 +55,39 @@
         }
       ]
     },
+    "beneficialOwners": {
+      "class": "BeneficialOwnersAPI",
+      "methods": [
+        {
+          "name": "confirmRoster",
+          "deprecated": false
+        },
+        {
+          "name": "create",
+          "deprecated": false
+        },
+        {
+          "name": "delete",
+          "deprecated": false
+        },
+        {
+          "name": "list",
+          "deprecated": false
+        },
+        {
+          "name": "resendInvite",
+          "deprecated": false
+        },
+        {
+          "name": "retrieve",
+          "deprecated": false
+        },
+        {
+          "name": "update",
+          "deprecated": false
+        }
+      ]
+    },
     "billing": {
       "class": "BillingAPI",
       "methods": [

--- a/tests/accounts.test.ts
+++ b/tests/accounts.test.ts
@@ -121,3 +121,15 @@ test('unrestrict account', async () => {
   const result = await accounts.unrestrict('acct_123');
   expect(result).toEqual(mockAccount);
 });
+
+test('getGeoCompliance → GET /v1/accounts/{id}/geo_compliance', async () => {
+  const body = {
+    status: 'clear',
+    sonar_session_id: 'sonar_1',
+    evaluated_at: 1234,
+  };
+  nock(baseUrl).get('/v1/accounts/acct_123/geo_compliance').reply(200, body);
+
+  const result = await accounts.getGeoCompliance('acct_123');
+  expect(result).toEqual(body);
+});

--- a/tests/beneficial_owners.test.ts
+++ b/tests/beneficial_owners.test.ts
@@ -1,0 +1,110 @@
+/// <reference types="jest" />
+
+import nock from 'nock';
+import { createApiClient } from '../src/client';
+import { BeneficialOwnersAPI } from '../src/api/beneficial_owners-api';
+
+const baseUrl = 'https://api.framepayments.com';
+const client = createApiClient({ apiKey: 'sk_test', publishableKey: 'pk_test' });
+const beneficialOwners = new BeneficialOwnersAPI(client);
+
+afterEach(() => nock.cleanAll());
+
+const mockOwner = {
+  id: 'bo_1',
+  object: 'beneficial_owner',
+  account_id: 'acct_eric',
+  first_name: 'Janet',
+  middle_name: null,
+  last_name: 'Jones',
+  suffix: null,
+  email: 'janet@example.com',
+  roles: ['owner', 'controller'],
+  percent_ownership: 50,
+  status: 'completed',
+  livemode: false,
+  created: 1,
+  updated: 1,
+};
+
+test('list → GET /v1/accounts/{id}/beneficial_owners', async () => {
+  nock(baseUrl)
+    .get('/v1/accounts/acct_eric/beneficial_owners')
+    .reply(200, { data: [mockOwner] });
+
+  const result = await beneficialOwners.list('acct_eric');
+  expect(result.data[0].id).toBe('bo_1');
+});
+
+test('create → POST /v1/accounts/{id}/beneficial_owners', async () => {
+  const params = {
+    first_name: 'Janet',
+    last_name: 'Jones',
+    email: 'janet@example.com',
+    roles: ['owner', 'controller'],
+  };
+  nock(baseUrl)
+    .post('/v1/accounts/acct_eric/beneficial_owners', params)
+    .reply(201, mockOwner);
+
+  const result = await beneficialOwners.create('acct_eric', params);
+  expect(result.id).toBe('bo_1');
+});
+
+test('create honors usePublishableKey', async () => {
+  nock(baseUrl, { reqheaders: { authorization: 'Bearer pk_test' } })
+    .post('/v1/accounts/acct_eric/beneficial_owners')
+    .reply(201, mockOwner);
+
+  await beneficialOwners.create(
+    'acct_eric',
+    { first_name: 'Janet', last_name: 'Jones', email: 'janet@example.com', roles: ['owner'] },
+    { usePublishableKey: true },
+  );
+});
+
+test('retrieve → GET /v1/accounts/{id}/beneficial_owners/{id}', async () => {
+  nock(baseUrl)
+    .get('/v1/accounts/acct_eric/beneficial_owners/bo_1')
+    .reply(200, mockOwner);
+
+  const result = await beneficialOwners.retrieve('acct_eric', 'bo_1');
+  expect(result.id).toBe('bo_1');
+});
+
+test('update → PATCH /v1/accounts/{id}/beneficial_owners/{id}', async () => {
+  const updates = { percent_ownership: 40, roles: ['owner'] };
+  nock(baseUrl)
+    .patch('/v1/accounts/acct_eric/beneficial_owners/bo_1', updates)
+    .reply(200, { ...mockOwner, ...updates });
+
+  const result = await beneficialOwners.update('acct_eric', 'bo_1', updates);
+  expect(result.percent_ownership).toBe(40);
+});
+
+test('delete → DELETE /v1/accounts/{id}/beneficial_owners/{id} (204)', async () => {
+  nock(baseUrl)
+    .delete('/v1/accounts/acct_eric/beneficial_owners/bo_1')
+    .reply(204);
+
+  await expect(beneficialOwners.delete('acct_eric', 'bo_1')).resolves.toBeUndefined();
+});
+
+test('confirmRoster → POST /v1/accounts/{id}/beneficial_owners/confirm returns account', async () => {
+  const account = { id: 'acct_eric', object: 'account', status: 'active' };
+  nock(baseUrl)
+    .post('/v1/accounts/acct_eric/beneficial_owners/confirm')
+    .reply(200, account);
+
+  const result = await beneficialOwners.confirmRoster('acct_eric');
+  expect(result.object).toBe('account');
+});
+
+test('resendInvite → POST /v1/accounts/{id}/beneficial_owners/{id}/resend_invite', async () => {
+  nock(baseUrl)
+    .post('/v1/accounts/acct_eric/beneficial_owners/bo_1/resend_invite')
+    .reply(200, { ...mockOwner, status: 'invite_sent' });
+
+  const result = await beneficialOwners.resendInvite('acct_eric', 'bo_1');
+  expect(result.status).toBe('invite_sent');
+});


### PR DESCRIPTION
## Summary

Adds the account-scoped **`beneficialOwners`** resource to the node SDK — the M2 canonical surface from [FRA-4460](https://linear.app/framepayments/issue/FRA-4460), part of the API Canonicalization (+ Parity) project.

New `BeneficialOwnersAPI` with the full documented surface, all scoped by `{account_id}`:

| Method | HTTP | Path |
|---|---|---|
| `list` | GET | `/v1/accounts/{account_id}/beneficial_owners` |
| `create` | POST | `/v1/accounts/{account_id}/beneficial_owners` |
| `retrieve` | GET | `.../beneficial_owners/{id}` |
| `update` | PATCH | `.../beneficial_owners/{id}` |
| `delete` | DELETE | `.../beneficial_owners/{id}` (204) |
| `confirmRoster` | POST | `.../beneficial_owners/confirm` → Account |
| `resendInvite` | POST | `.../beneficial_owners/{id}/resend_invite` |

It mirrors the existing `capabilities` / `phoneVerifications` sub-resource classes (plain class holding the axios instance, `accountId` as the first arg, `maybePublishableKey(opts)`).

### Also in this PR
- `accounts.getGeoCompliance` now accepts `RequestOptions` (`usePublishableKey`), matching `geoCompliance.getAccountStatus`, which hits the same endpoint.
- Regenerated `surface-manifest.json` (adds the `beneficialOwners` block; no other resource changes).

## Testing
- `tests/beneficial_owners.test.ts` — all 7 methods, publishable-key opt-in, 204 delete, roster-confirm returns an Account.
- Backfilled `accounts.getGeoCompliance` coverage in `tests/accounts.test.ts`.
- `npm run typecheck` ✅, `npm test` (219 passing) ✅, `npm run build` ✅.

## Notes
- Surface mirrors the documented API exactly — no undocumented params/fields added.
- Companion PRs in frame-ruby, frame-php, and frame (swagger `x-frame-sdk` annotations) complete the cross-SDK parity for this resource.

🤖 Generated with [Claude Code](https://claude.com/claude-code)