### PR TITLE
test: add payouts.create coverage (FRA-4464)

### DIFF
--- a/tests/payouts.test.ts
+++ b/tests/payouts.test.ts
@@ -1,0 +1,57 @@
+/// <reference types="jest" />
+import axios from 'axios';
+import nock from 'nock';
+import { PayoutsAPI } from '../src/api/payouts-api';
+import type { Payout, CreatePayoutParams } from '../src/types/payouts';
+
+const baseUrl = 'https://api.framepayments.com';
+const client = axios.create({ baseURL: baseUrl });
+const payouts = new PayoutsAPI(client);
+
+const mockPayout: Payout = {
+  id: 'po_123',
+  object: 'payout',
+  amount: 5000,
+  currency: 'usd',
+  status: 'pending',
+  payment_method_id: 'pm_dst_456',
+  account_id: 'acct_123',
+  metadata: {},
+  created: 1713435744,
+  updated: 1713435744,
+  livemode: true,
+};
+
+afterEach(() => nock.cleanAll());
+
+test('create payout - merchant earnings withdrawal', async () => {
+  const input: CreatePayoutParams = {
+    amount: 5000,
+    currency: 'usd',
+    payment_method_id: 'pm_dst_456',
+  };
+
+  nock(baseUrl).post('/v1/payouts', input as any).reply(200, mockPayout);
+
+  const result = await payouts.create(input);
+  expect(result).toEqual(mockPayout);
+});
+
+test('create payout - with metadata', async () => {
+  const input: CreatePayoutParams = {
+    amount: 5000,
+    currency: 'usd',
+    payment_method_id: 'pm_dst_456',
+    metadata: { invoice: 'inv_789' },
+  };
+
+  const expected: Payout = {
+    ...mockPayout,
+    metadata: { invoice: 'inv_789' },
+  };
+
+  nock(baseUrl).post('/v1/payouts', input as any).reply(200, expected);
+
+  const result = await payouts.create(input);
+  expect(result).toEqual(expected);
+});


### PR DESCRIPTION
## Summary

Adds node test coverage for the **`payouts.create`** dedicated method — the M2 canonical surface from [FRA-4464](https://linear.app/framepayments/issue/FRA-4464), part of the API Canonicalization (+ Parity) project.

**The SDK side is already complete.** `PayoutsAPI.create` already hits `POST /v1/payouts` and is the only payout method exposed by the node SDK — there is no stray `retrieve` (payout vocab = `create` only). `payouts.create` is a merchant's own earnings withdrawal, semantically distinct from a Transfer, and it is correctly merchant-scoped (no publishable-key opts).

| Method | HTTP | Path |
|---|---|---|
| `create` | POST | `/v1/payouts` |

### What this PR changes
- **`tests/payouts.test.ts`** — new. Covers `payouts.create` (merchant earnings withdrawal + metadata pass-through), following the nock + axios style of `tests/transfers.test.ts`.
- Regenerated `surface-manifest.json` — **no change** (manifest already reflected `payouts.create`).

## Not in this repo — MONOLITH work owned by Ryan

The substantive part of FRA-4464 is a **MONOLITH task owned by Ryan**: un-deprecate `POST /v1/payouts` in openapi and add `x-frame-sdk: payouts.create`. That is **out of scope for frame-node** — no openapi / rswag / monolith changes belong here, and none were made.

## Testing
- `npm run typecheck` ✅
- `npm test` (221 passing) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)