### PR TITLE
feat: transfers.confirm + chargeIntents demotion (FRA-4462)

### DIFF
--- a/src/api/charge_intents-api.ts
+++ b/src/api/charge_intents-api.ts
@@ -12,21 +12,25 @@ import { maybePublishableKey, type RequestOptions } from '../client';
 export class ChargeIntentsAPI {
   constructor(private client: AxiosInstance) {}
 
+  /** @deprecated Use `transfers.create` instead. Removed at v2. */
   async create(params: CreateChargeIntentParams, opts?: RequestOptions): Promise<ChargeIntent> {
     const resp = await this.client.post('/v1/charge_intents', params, maybePublishableKey(opts));
     return resp.data;
   }
 
+  /** @deprecated Removed at v2. No canonical transfer equivalent yet (FRA-4463). */
   async update(id: string, params: UpdateChargeIntentParams): Promise<ChargeIntent> {
     const resp = await this.client.patch(`/v1/charge_intents/${id}`, params);
     return resp.data;
   }
 
+  /** @deprecated Use `transfers.retrieve` instead. Removed at v2. */
   async get(id: string, opts?: RequestOptions): Promise<ChargeIntent> {
     const resp = await this.client.get(`/v1/charge_intents/${id}`, maybePublishableKey(opts));
     return resp.data;
   }
 
+  /** @deprecated Use `transfers.list` instead. Removed at v2. */
   async list(per_page?: number, page?: number): Promise<ChargeIntentListResponse> {
     const resp = await this.client.get('/v1/charge_intents', { params: { per_page, page } });
     return resp.data;
@@ -41,21 +45,25 @@ export class ChargeIntentsAPI {
           }, per_page);
         }
 
+  /** @deprecated Removed at v2. No canonical transfer equivalent yet (FRA-4463). */
   async cancel(id: string): Promise<ChargeIntent> {
     const resp = await this.client.post(`/v1/charge_intents/${id}/cancel`);
     return resp.data;
   }
 
+  /** @deprecated Use `transfers.confirm` instead. Removed at v2. */
   async confirm(id: string, opts?: RequestOptions): Promise<ChargeIntent> {
     const resp = await this.client.post(`/v1/charge_intents/${id}/confirm`, undefined, maybePublishableKey(opts));
     return resp.data;
   }
 
+  /** @deprecated Removed at v2. No canonical transfer equivalent yet (FRA-4463). */
   async capture(id: string, params?: CaptureChargeIntentParams): Promise<ChargeIntent> {
     const resp = await this.client.post(`/v1/charge_intents/${id}/capture`, params);
     return resp.data;
   }
 
+  /** @deprecated Removed at v2. No canonical transfer equivalent yet (FRA-4463). */
   async voidRemaining(id: string): Promise<ChargeIntent> {
     const resp = await this.client.post(`/v1/charge_intents/${id}/void_remaining`);
     return resp.data;

--- a/src/api/charge_intents-api.ts
+++ b/src/api/charge_intents-api.ts
@@ -36,6 +36,7 @@ export class ChargeIntentsAPI {
     return resp.data;
   }
 
+  /** @deprecated Use `transfers.iterateAllTransfers` instead. Removed at v2. */
   async iterateAllChargeIntents(per_page = 20) {
           return paginate<ChargeIntent>(async (page: number) => {
             const res = await this.client.get('/v1/charge_intents', {

--- a/src/api/transfers-api.ts
+++ b/src/api/transfers-api.ts
@@ -26,6 +26,11 @@ export class TransfersAPI {
     return resp.data;
   }
 
+  async confirm(id: string, opts?: RequestOptions): Promise<Transfer> {
+    const resp = await this.client.post(`/v1/transfers/${id}/confirm`, undefined, maybePublishableKey(opts));
+    return resp.data;
+  }
+
   async iterateAllTransfers(per_page = 20) {
     return paginate<Transfer>(async (page: number) => {
       const res = await this.client.get('/v1/transfers', { params: { per_page, page } });

--- a/surface-manifest.json
+++ b/surface-manifest.json
@@ -183,19 +183,19 @@
         },
         {
           "name": "confirm",
-          "deprecated": false
+          "deprecated": true
         },
         {
           "name": "create",
-          "deprecated": false
+          "deprecated": true
         },
         {
           "name": "get",
-          "deprecated": false
+          "deprecated": true
         },
         {
           "name": "list",
-          "deprecated": false
+          "deprecated": true
         },
         {
           "name": "update",
@@ -946,6 +946,10 @@
     "transfers": {
       "class": "TransfersAPI",
       "methods": [
+        {
+          "name": "confirm",
+          "deprecated": false
+        },
         {
           "name": "create",
           "deprecated": false

--- a/tests/charge_intents.test.ts
+++ b/tests/charge_intents.test.ts
@@ -107,3 +107,46 @@ test('capture charge intent — partial amount via amount_captured_cents', async
   const result = await chargeIntents.capture('ci_123', { amount_captured_cents: 500 });
   expect(result).toEqual(mockChargeIntent);
 });
+
+// Deprecated aliases (create/get/list/confirm) remain functional and keep
+// returning the legacy ChargeIntent type by continuing to hit the
+// /v1/charge_intents endpoints — they are NOT forwarded to /v1/transfers,
+// which would change the return type. See FRA-4462.
+test('deprecated create still hits /v1/charge_intents', async () => {
+  const input = { amount: 1500, currency: 'usd' };
+
+  const scope = nock(baseUrl).post('/v1/charge_intents', input).reply(200, mockChargeIntent);
+
+  const result = await chargeIntents.create(input as any);
+  expect(result).toEqual(mockChargeIntent);
+  expect(scope.isDone()).toBe(true);
+});
+
+test('deprecated get still hits /v1/charge_intents/:id', async () => {
+  const scope = nock(baseUrl).get('/v1/charge_intents/ci_123').reply(200, mockChargeIntent);
+
+  const result = await chargeIntents.get('ci_123');
+  expect(result).toEqual(mockChargeIntent);
+  expect(scope.isDone()).toBe(true);
+});
+
+test('deprecated list still hits /v1/charge_intents', async () => {
+  const response = { data: [mockChargeIntent], page: 1, per_page: 10, total: 1 };
+
+  const scope = nock(baseUrl)
+    .get('/v1/charge_intents')
+    .query({ per_page: 10, page: 1 })
+    .reply(200, response);
+
+  const result = await chargeIntents.list(10, 1);
+  expect(result).toEqual(response);
+  expect(scope.isDone()).toBe(true);
+});
+
+test('deprecated confirm still hits /v1/charge_intents/:id/confirm', async () => {
+  const scope = nock(baseUrl).post('/v1/charge_intents/ci_123/confirm').reply(200, mockChargeIntent);
+
+  const result = await chargeIntents.confirm('ci_123');
+  expect(result).toEqual(mockChargeIntent);
+  expect(scope.isDone()).toBe(true);
+});

--- a/tests/transfers.test.ts
+++ b/tests/transfers.test.ts
@@ -124,6 +124,15 @@ test('retrieve transfer', async () => {
   expect(result).toEqual(mockTransfer);
 });
 
+test('confirm transfer', async () => {
+  const confirmed: Transfer = { ...mockTransfer, status: 'succeeded' };
+
+  nock(baseUrl).post('/v1/transfers/tr_123/confirm').reply(200, confirmed);
+
+  const result = await transfers.confirm('tr_123');
+  expect(result).toEqual(confirmed);
+});
+
 test('list transfers', async () => {
   const response = { data: [mockTransfer], meta: listMeta };
 


### PR DESCRIPTION
## Summary

M2 canonicalization ([FRA-4462](https://linear.app/framepayments/issue/FRA-4462), part of API Canonicalization + Parity): promotes **`transfers`** as the canonical surface and demotes **`chargeIntents`** to deprecated aliases.

Adds the confirm endpoint to transfers and marks the charge-intent methods `@deprecated`, pointing callers at their transfers equivalents. Additive only — nothing removed.

| Method | HTTP | Path |
|---|---|---|
| `transfers.confirm` (new) | POST | `/v1/transfers/{id}/confirm` |
| `transfers.retrieve` (canonical, pre-existing) | GET | `/v1/transfers/{id}` |
| `transfers.get` (deprecated → `retrieve`) | GET | `/v1/transfers/{id}` |
| `chargeIntents.create` (deprecated) | POST | `/v1/charge_intents` |
| `chargeIntents.get` (deprecated) | GET | `/v1/charge_intents/{id}` |
| `chargeIntents.list` (deprecated) | GET | `/v1/charge_intents` |
| `chargeIntents.confirm` (deprecated) | POST | `/v1/charge_intents/{id}/confirm` |

`transfers.confirm` mirrors `chargeIntents.confirm`: `POST` with an `undefined` body plus `maybePublishableKey(opts)`.

### Also in this PR
- `chargeIntents.{update,capture,cancel,voidRemaining}` are marked `@deprecated` but remain **functional against `/v1/charge_intents`** — their canonical transfer equivalents don't exist yet (blocked on FRA-4463).
- Regenerated `surface-manifest.json` (chargeIntents methods flagged deprecated; `transfers.confirm` added).

### Decision: chargeIntents aliases are NOT forwarded to transfers
The demoted `chargeIntents.{create,get,list,confirm}` continue to hit the `/v1/charge_intents` endpoints rather than forwarding to `transfers.*`. Forwarding would change their return type (`ChargeIntent`/`ChargeIntentListResponse` → `Transfer`/`TransferListResponse`), which is a breaking change to a still-shipping method and violates the additive-only rule. Per the ticket's guidance ("if the deprecated alias must return the legacy type, keep the legacy request rather than forwarding"), they keep the legacy request and only gain `@deprecated` JSDoc pointing to the canonical method. This also means `ChargeIntentsAPI` still needs only an `AxiosInstance` — no cross-resource constructor injection and no `src/index.ts` change (no existing resource does cross-resource forwarding; `threeDS` merely aliases the same instance).

## Testing
- `tests/transfers.test.ts` — added a `confirm` test (POST, returns updated Transfer).
- `tests/charge_intents.test.ts` — added tests asserting the deprecated `create`/`get`/`list`/`confirm` aliases still hit `/v1/charge_intents` and return `ChargeIntent`.
- `npm run typecheck` ✅
- `npm test` ✅ (224 passing, 28 suites)
- `npm run surface:manifest` regenerated ✅

## Out of scope / not touched
- `fraud_decline` (risk op, excluded).
- No rswag/openapi/monolith changes (separate repos).
- Canonical transfer equivalents for update/capture/cancel/void (FRA-4463).

🤖 Generated with [Claude Code](https://claude.com/claude-code)