### PR TITLE
feat: export PaymentMethod types/enums from entry point (FRA-4713) (2.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.1
+
+- **Restored payment-method public types at the entry point (FRA-4713).** The 2.4.0 dual CJS/ESM bundle only re-exported the Apple/Google Pay types; the general payment-method types — present in the built declarations but not exported — are now importable directly from `framepayments`: the `PaymentMethodType`, `PaymentAccountType`, and `PaymentMethodStatus` enums (runtime values) plus the `PaymentMethod`, `PaymentCard`, `BankAccount`, `PaymentMethodListResponse`, and `Address` types. These are the shape of `paymentMethods.createCard` / `.createACH` results and the enums needed to build their params. This restores the types removed from the old `framepayments/dist/types/payment_methods` deep-import path, so consumers (e.g. frame-react-native) can drop their local mirror. Types/enums only — no behavior change.
+
 ## 2.4.0
 
 Publishable-key-only mobile clients (starting with `framepayments-react-native`, FRA-4315) can now authenticate **onboarding sessions** and **per-object client secrets**, matching the three-tier auth resolver of the native Frame iOS / Android SDKs (FRA-4712).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "framepayments",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "The Frame Node.js Library simplifies the process of creating a seamless payment experience within your web app. it provides access to the underlying APIs that drive these components, allowing you to design fully customized payment workflows tailored to your app's needs.",
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.cts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "framepayments",
-  "version": "2.4.1",
+  "version": "2.6.0",
   "description": "The Frame Node.js Library simplifies the process of creating a seamless payment experience within your web app. it provides access to the underlying APIs that drive these components, allowing you to design fully customized payment workflows tailored to your app's needs.",
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.cts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,22 @@ export type {
   AttestResponse,
 } from './types/device_attestation';
 export type { GooglePayConfiguration } from './types/wallet';
+
+// Payment-method enums are runtime values (used to build create params), so
+// they must be exported as values, not `export type`. Interfaces below are
+// type-only. Restores the public types dropped from the 2.4.0 deep-import path.
+export {
+  PaymentMethodType,
+  PaymentAccountType,
+  PaymentMethodStatus,
+} from './types/payment_methods';
+export type {
+  PaymentMethod,
+  PaymentCard,
+  BankAccount,
+  PaymentMethodListResponse,
+} from './types/payment_methods';
+export type { Address } from './types/customers';
 export type {
   ApplePayPaymentDataHeader,
   ApplePayPaymentData,

--- a/surface-manifest.json
+++ b/surface-manifest.json
@@ -1,6 +1,6 @@
 {
   "sdk": "frame-node",
-  "version": "2.4.1",
+  "version": "2.6.0",
   "resources": {
     "accounts": {
       "class": "AccountsAPI",

--- a/surface-manifest.json
+++ b/surface-manifest.json
@@ -1,6 +1,6 @@
 {
   "sdk": "frame-node",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "resources": {
     "accounts": {
       "class": "AccountsAPI",

--- a/tests/entry_exports.test.ts
+++ b/tests/entry_exports.test.ts
@@ -1,0 +1,56 @@
+/// <reference types="jest" />
+
+// Guard test for FRA-4713: the payment-method public types/enums must remain
+// importable from the package entry point. The 2.4.0 bundle dropped them from
+// the deep-import path, forcing consumers (frame-react-native) to mirror them
+// locally. These imports failing to resolve is the regression we're guarding.
+import {
+  PaymentMethodType,
+  PaymentAccountType,
+  PaymentMethodStatus,
+} from '../src/index';
+import type {
+  PaymentMethod,
+  PaymentCard,
+  BankAccount,
+  PaymentMethodListResponse,
+  Address,
+} from '../src/index';
+
+describe('entry-point payment-method exports', () => {
+  it('re-exports the enums as runtime values with the expected members', () => {
+    expect(PaymentMethodType.CARD).toBe('card');
+    expect(PaymentMethodType.ACH).toBe('ach');
+    expect(PaymentAccountType.CHECKING).toBe('checking');
+    expect(PaymentAccountType.SAVINGS).toBe('savings');
+    expect(PaymentMethodStatus.ACTIVE).toBe('active');
+    expect(PaymentMethodStatus.BLOCKED).toBe('blocked');
+    expect(PaymentMethodStatus.DETACHED).toBe('detached');
+  });
+
+  it('re-exports the public types (compile-time assertion)', () => {
+    // If any of these types were not exported from the entry point, this file
+    // would fail to typecheck. The runtime body just anchors the assertion.
+    const card: PaymentCard = {
+      brand: 'visa',
+      exp_month: '01',
+      exp_year: '2030',
+      last_four: '4242',
+    };
+    const bank: BankAccount = { account_type: PaymentAccountType.CHECKING };
+    const billing: Address = {} as Address;
+    const method: PaymentMethod = {
+      id: 'pm_test',
+      type: PaymentMethodType.CARD,
+      livemode: false,
+      created: 0,
+      status: PaymentMethodStatus.ACTIVE,
+      card,
+      ach: bank,
+      billing,
+    };
+    const list: PaymentMethodListResponse = { data: [method] };
+
+    expect(list.data?.[0].id).toBe('pm_test');
+  });
+});


### PR DESCRIPTION
## Summary

Restores the payment-method public types/enums to `frame-node`'s entry point. Closes **FRA-4713** (and its duplicate **FRA-4714**), the last open work on the SDK track (**FRA-4312**).

The 2.4.0 dual CJS/ESM bundle exposes only the package root in its `exports` map, and its bundled declarations re-exported only the Apple/Google Pay types. The general payment-method types — the shape of `paymentMethods.createCard` / `.createACH` results and the enums needed to build their params — were present in `dist/index.d.cts` but not exported from the root, so neither the old `framepayments/dist/types/payment_methods` deep import nor a top-level import resolved. Consumers (frame-react-native) had to mirror them locally in `src/framepaymentsTypes.ts`.

## Changes

- **`src/index.ts`** — export from the entry point:
  - **enums** (runtime values, `export {}` not `export type`): `PaymentMethodType`, `PaymentAccountType`, `PaymentMethodStatus`
  - **types**: `PaymentMethod`, `PaymentCard`, `BankAccount`, `PaymentMethodListResponse`, `Address`
- **`tests/entry_exports.test.ts`** — guard test: enums resolve at runtime with the expected members; the types resolve at compile time.
- **Version** bumped to `2.4.1`; `CHANGELOG.md` and `surface-manifest.json` updated.

Types/enums only — no behavior change.

## Verification

- `npm run typecheck` ✅
- `npm test` — 230 passed, 30 suites ✅
- `npm run build` ✅ — confirmed the built `.d.cts`/`.d.mts` export the enums as **values** and the interfaces as `type`, and the `.mjs`/`.cjs` runtime bundles export the enum objects.

## Downstream

Once 2.4.1 ships, frame-react-native can delete its local `src/framepaymentsTypes.ts` mirror and switch its 6 import sites back to `import { ... } from 'framepayments'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
