### PR TITLE
feat: add bankAccounts resource (create + retrieve) [FRA-5294]

### DIFF
--- a/src/api/bank_accounts-api.ts
+++ b/src/api/bank_accounts-api.ts
@@ -1,0 +1,17 @@
+import type { AxiosInstance } from 'axios';
+import type { BankAccount, CreateBankAccountParams } from '../types/bank_accounts';
+import { maybePublishableKey, type RequestOptions } from '../client';
+
+export class BankAccountsAPI {
+  constructor(private client: AxiosInstance) {}
+
+  async create(params: CreateBankAccountParams, opts?: RequestOptions): Promise<BankAccount> {
+    const resp = await this.client.post('/v1/bank_accounts', params, maybePublishableKey(opts));
+    return resp.data;
+  }
+
+  async retrieve(id: string): Promise<BankAccount> {
+    const resp = await this.client.get(`/v1/bank_accounts/${id}`);
+    return resp.data;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { CapabilitiesAPI } from './api/capabilities-api';
 import { OnboardingSessionsAPI } from './api/onboarding_sessions-api';
 import { CustomersAPI } from './api/customers-api';
 import { PaymentMethodsAPI } from './api/payment_methods-api';
+import { BankAccountsAPI } from './api/bank_accounts-api';
 import { ChargeIntentsAPI } from './api/charge_intents-api';
 import { RefundsAPI } from './api/refunds-api';
 import { SubscriptionsAPI } from './api/subscriptions-api';
@@ -70,6 +71,13 @@ export type {
   BankAccount,
   PaymentMethodListResponse,
 } from './types/payment_methods';
+// `BankAccount` (the standalone /v1/bank_accounts resource) is re-exported as
+// `BankAccountResource` to avoid colliding with the payment-method `BankAccount`
+// sub-shape exported just above.
+export type {
+  BankAccount as BankAccountResource,
+  CreateBankAccountParams,
+} from './types/bank_accounts';
 export type { Address } from './types/customers';
 export type {
   ApplePayPaymentDataHeader,
@@ -106,6 +114,7 @@ export class FrameSDK {
   public onboardingSessions: OnboardingSessionsAPI;
   public customers: CustomersAPI;
   public paymentMethods: PaymentMethodsAPI;
+  public bankAccounts: BankAccountsAPI;
   public chargeIntents: ChargeIntentsAPI;
   public refunds: RefundsAPI;
   public subscriptions: SubscriptionsAPI;
@@ -157,6 +166,7 @@ export class FrameSDK {
     this.onboardingSessions = new OnboardingSessionsAPI(client);
     this.customers = new CustomersAPI(client);
     this.paymentMethods = new PaymentMethodsAPI(client);
+    this.bankAccounts = new BankAccountsAPI(client);
     this.chargeIntents = new ChargeIntentsAPI(client);
     this.refunds = new RefundsAPI(client);
     this.subscriptions = new SubscriptionsAPI(client);

--- a/src/types/bank_accounts.ts
+++ b/src/types/bank_accounts.ts
@@ -1,0 +1,38 @@
+import type { PaymentAccountType } from './payment_methods';
+
+/**
+ * A bank account resource (`ba_…`) connected through a processor (e.g. Plaid),
+ * owned by a customer or an account.
+ *
+ * Distinct from the `BankAccount` sub-shape in `./payment_methods`, which is the
+ * ACH detail embedded on a payment method. This is the standalone
+ * `/v1/bank_accounts` object; re-exported from the package root as
+ * `BankAccountResource` to avoid a name collision with that sub-shape.
+ */
+export interface BankAccount {
+  id: string;
+  object?: string;
+  routing_number?: string;
+  account_number_last_4?: string;
+  account_type?: PaymentAccountType;
+  bank_name?: string;
+  processor_name?: string;
+  status?: string;
+  customer_id?: string | null;
+  account_id?: string | null;
+  created?: number;
+  updated?: number;
+  livemode?: boolean;
+}
+
+/** Params for `bankAccounts.create` (`POST /v1/bank_accounts`). */
+export interface CreateBankAccountParams {
+  /** Processor used to connect the account, e.g. `"plaid"`. */
+  processor: string;
+  /** Processor-issued token for the connected account. */
+  processor_token: string;
+  /** Owning customer (`cus_…`). Provide this or `account_id`. */
+  customer_id?: string;
+  /** Owning account (`acct_…`). Provide this or `customer_id`. */
+  account_id?: string;
+}

--- a/surface-manifest.json
+++ b/surface-manifest.json
@@ -59,6 +59,19 @@
         }
       ]
     },
+    "bankAccounts": {
+      "class": "BankAccountsAPI",
+      "methods": [
+        {
+          "name": "create",
+          "deprecated": false
+        },
+        {
+          "name": "retrieve",
+          "deprecated": false
+        }
+      ]
+    },
     "beneficialOwners": {
       "class": "BeneficialOwnersAPI",
       "methods": [

--- a/tests/bank_accounts.test.ts
+++ b/tests/bank_accounts.test.ts
@@ -1,0 +1,50 @@
+/// <reference types="jest" />
+
+import { BankAccountsAPI } from '../src/api/bank_accounts-api';
+import { PaymentAccountType } from '../src/types/payment_methods';
+import { BankAccount, CreateBankAccountParams } from '../src/types/bank_accounts';
+import nock from 'nock';
+import { createApiClient } from '../src/client';
+
+const baseUrl = 'https://api.framepayments.com';
+const client = createApiClient({ apiKey: 'sk_test', publishableKey: 'pk_test' });
+const bankAccounts = new BankAccountsAPI(client);
+
+const mockBankAccount: BankAccount = {
+  id: 'ba_1234567890abcdef',
+  object: 'bank_account',
+  routing_number: '110000000',
+  account_number_last_4: '6789',
+  account_type: PaymentAccountType.CHECKING,
+  bank_name: 'Test Bank',
+  processor_name: 'plaid',
+  status: 'active',
+  customer_id: 'cus_1234567890abcdef',
+  account_id: null,
+  created: 1640995200,
+  updated: 1640995200,
+  livemode: false,
+};
+
+afterEach(() => {
+  nock.cleanAll();
+});
+
+test('create bank account', async () => {
+  const input: CreateBankAccountParams = {
+    processor: 'plaid',
+    processor_token: 'processor-sandbox-token',
+    customer_id: 'cus_1234567890abcdef',
+  };
+  nock(baseUrl).post('/v1/bank_accounts', input).reply(201, mockBankAccount);
+
+  const result = await bankAccounts.create(input);
+  expect(result).toEqual(mockBankAccount);
+});
+
+test('retrieve bank account', async () => {
+  nock(baseUrl).get('/v1/bank_accounts/ba_1234567890abcdef').reply(200, mockBankAccount);
+
+  const result = await bankAccounts.retrieve('ba_1234567890abcdef');
+  expect(result).toEqual(mockBankAccount);
+});


### PR DESCRIPTION
## What

Adds the canonical `bankAccounts` resource to frame-node — `create` (POST /v1/bank_accounts) and `retrieve` (GET /v1/bank_accounts/{id}) — wired on the `FrameSDK` client. Part of FRA-5294, bringing all three backend SDKs to parity on `bankAccounts` (ruby already shipped it; node/php lacked it).

## Notes

- The resource object type is exported from the package root as **`BankAccountResource`** to avoid colliding with the existing payment-method `BankAccount` sub-shape (the ACH detail embedded on a payment method). In-module / method-return type is `BankAccount`.
- `surface-manifest.json` regenerated → `bankAccounts` now lists `create`, `retrieve`.

## Convergence

Sibling PRs: frame-php + frame-ruby (SDK side) and frame (monolith: adds the real GET endpoint + `x-frame-sdk` annotations). **Merge the SDK PRs before the monolith PR** so the monolith parity audit sees the updated manifests. After all merge: bankAccounts = 100% parity across node/ruby/php.

## Test

`npx tsc --noEmit` clean; `jest tests/bank_accounts.test.ts` green (create + retrieve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)