### PR TITLE
feat: add subscriptions.cancelScheduledChange [FRA-5441]

### DIFF
--- a/src/api/subscriptions-api.ts
+++ b/src/api/subscriptions-api.ts
@@ -64,4 +64,9 @@ export class SubscriptionsAPI {
     const resp = await this.client.post(`/v1/subscriptions/${id}/resume`);
     return resp.data;
   }
+
+  async cancelScheduledChange(id: string): Promise<Subscription> {
+    const resp = await this.client.delete(`/v1/subscriptions/${id}/scheduled_change`);
+    return resp.data;
+  }
 }

--- a/src/types/subscriptions.ts
+++ b/src/types/subscriptions.ts
@@ -22,6 +22,15 @@ export interface PlanDetails {
   livemode: boolean;
 }
 
+export interface SubscriptionScheduledChange {
+  id: string;
+  object: string; // Always "subscription_scheduled_change".
+  product: string; // ID of the product the subscription will change to at next renewal.
+  interval_switch: boolean; // Whether the change also switches billing interval.
+  effective_date: number; // Unix ts when the change takes effect; tracks current period end.
+  created: number; // Unix ts when the change was scheduled.
+}
+
 export interface Subscription {
   id: string;
   description?: string;
@@ -44,6 +53,7 @@ export interface Subscription {
   effective_interval?: string | null;
   effective_interval_count?: number | null;
   latest_charge_intent?: string | null;
+  scheduled_change?: SubscriptionScheduledChange | null;
   object?: string;
   created?: number;
   updated?: number;

--- a/surface-manifest.json
+++ b/surface-manifest.json
@@ -851,6 +851,10 @@
           "deprecated": false
         },
         {
+          "name": "cancelScheduledChange",
+          "deprecated": false
+        },
+        {
           "name": "create",
           "deprecated": false
         },

--- a/tests/subscriptions.test.ts
+++ b/tests/subscriptions.test.ts
@@ -144,7 +144,7 @@ const mockScheduledChange = {
   created: 1234567890,
 };
 
-test('cancelScheduledChange clears the pending scheduled change', async () => {
+test('cancel scheduled change', async () => {
   const cleared: Subscription = { ...mockSubscription, scheduled_change: null };
 
   nock(baseUrl)
@@ -156,7 +156,7 @@ test('cancelScheduledChange clears the pending scheduled change', async () => {
   expect(result.scheduled_change).toBeNull();
 });
 
-test('subscription deserializes a populated scheduled_change', async () => {
+test('retrieve subscription with scheduled change', async () => {
   const subWithChange: Subscription = {
     ...mockSubscription,
     scheduled_change: mockScheduledChange,

--- a/tests/subscriptions.test.ts
+++ b/tests/subscriptions.test.ts
@@ -134,3 +134,37 @@ test('resume subscription', async () => {
   const result = await subscriptions.resume('sub_123');
   expect(result).toEqual(mockSubscription);
 });
+
+const mockScheduledChange = {
+  id: 'ssc_123',
+  object: 'subscription_scheduled_change',
+  product: 'prod_456',
+  interval_switch: false,
+  effective_date: 1234599999,
+  created: 1234567890,
+};
+
+test('cancelScheduledChange clears the pending scheduled change', async () => {
+  const cleared: Subscription = { ...mockSubscription, scheduled_change: null };
+
+  nock(baseUrl)
+    .delete('/v1/subscriptions/sub_123/scheduled_change')
+    .reply(200, cleared);
+
+  const result = await subscriptions.cancelScheduledChange('sub_123');
+  expect(result).toEqual(cleared);
+  expect(result.scheduled_change).toBeNull();
+});
+
+test('subscription deserializes a populated scheduled_change', async () => {
+  const subWithChange: Subscription = {
+    ...mockSubscription,
+    scheduled_change: mockScheduledChange,
+  };
+
+  nock(baseUrl).get('/v1/subscriptions/sub_123').reply(200, subWithChange);
+
+  const result = await subscriptions.retrieve('sub_123');
+  expect(result).toEqual(subWithChange);
+  expect(result.scheduled_change).toEqual(mockScheduledChange);
+});


### PR DESCRIPTION
## Ticket

[FRA-5441](https://linear.app/framepayments/issue/FRA-5441/sdk-parity-build-subscriptionscancelscheduledchange-across-frame)

## What

Adds the canonical `frame.subscriptions.cancelScheduledChange(id)` method: `DELETE /v1/subscriptions/{id}/scheduled_change`, returning the `Subscription` with `scheduled_change` cleared to `null`. The API returns 404 when the subscription doesn't exist **or** no change is pending; errors surface through the shared client interceptor exactly like the sibling action methods (`cancel`/`pause`/`resume`).

Also adds the previously missing `scheduled_change` field to the `Subscription` type — new `SubscriptionScheduledChange` interface (`id`, `object`, `product`, `interval_switch`, `effective_date`, `created`, matching the public OpenAPI schema's required set), declared `?: SubscriptionScheduledChange | null` per the file's convention — and regenerates `surface-manifest.json` via `npm run surface:manifest`.

Canonical name confirmed against the registry (`frame-docs/lib/sdk-docs-standards/CROSS_SDK_NAMING.md`). Closes the parity gap recorded by FRA-5404 / Frame-Payments/frame#3946, which documented the endpoint but left it un-annotated pending this method.

## How to Test

- `npm test` → 234 passed, 0 failed (2 new tests: DELETE hits the right path and resolves the cleared subscription; a populated `scheduled_change` deserializes)
- `npm run typecheck` and `npm run build` → clean
- From a monolith checkout with sibling SDK clones: `bundle exec rake sdk_parity:audit` → frame-node 100% (138/138), 0 missing

## Notes

- The monolith PR annotating `cancelSubscriptionScheduledChange` with `x-frame-sdk` should merge **after** this one (no phantom annotations, per SDK_PARITY_POLICY).
- Pre-existing (not addressed here): `Subscription`/`PlanDetails` types aren't re-exported from the package root, so the new interface isn't either.
